### PR TITLE
fix Graph API request

### DIFF
--- a/docs/identity/authentication/how-to-certificate-based-authentication.md
+++ b/docs/identity/authentication/how-to-certificate-based-authentication.md
@@ -516,11 +516,6 @@ To enable CBA and configure username bindings using Graph API, complete the foll
                 "x509CertificateField": "RFC822Name",
                 "userProperty": "userPrincipalName",
                 "priority": 2
-            }, 
-            {
-                "x509CertificateField": "PrincipalName",
-                "userProperty": "certificateUserIds",
-                "priority": 3
             }
         ],
         "authenticationModeConfiguration": {


### PR DESCRIPTION
Remove duplicated options from the body parameters in the API call examples. These options were causing badRequest errors during API calls. This change aims to clarify the documentation and ensure users have a smoother experience with our API.

![image](https://github.com/MicrosoftDocs/entra-docs/assets/28978715/6b5dd09b-c735-4433-93f7-a26a2dda898e)
