### PR TITLE
Minor update to concept-microsoft-entra-health.md

### DIFF
--- a/docs/identity/monitoring-health/concept-microsoft-entra-health.md
+++ b/docs/identity/monitoring-health/concept-microsoft-entra-health.md
@@ -14,7 +14,7 @@ ms.reviewer: sarbar
 
 # What is Microsoft Entra Health?
 
-Microsoft Entra Health (preview) provides you with the ability to view the health of your Microsoft Entra tenant through a report of service level agreement (SLA) attainment and a set of health metrics you can monitor for key Microsoft Entra ID scenarios. All the data is provided at the tenant level. The scenario monitoring solution is currently in public preview and can be enabled or disabled in the Preview Hub; the SLA Attainment report is generally available.
+Microsoft Entra Health (preview) provides you with the ability to view the health of your Microsoft Entra tenant through a report of service level agreement (SLA) attainment and a set of health metrics you can monitor for key Microsoft Entra ID scenarios. All the data is provided at the tenant level. The scenario monitoring solution is currently in public preview and can be enabled or disabled in the Preview Hub; the SLA Attainment report is available by default.
 
 ## How to access Microsoft Entra Health
 


### PR DESCRIPTION
I clarified in the intro that SLA attainment reporting is available by default. The language had stated that it's "generally available" but it's not actually GA; it's just that it is turned on by default in the Preview Hub (so in practice it is available to all qualifying tenants without an admin needing to enable the feature).