### PR TITLE
Update howto-conditional-access-policy-block-legacy.md

### DIFF
--- a/docs/identity/conditional-access/howto-conditional-access-policy-block-legacy.md
+++ b/docs/identity/conditional-access/howto-conditional-access-policy-block-legacy.md
@@ -33,7 +33,7 @@ The following steps will help create a Conditional Access policy to block legacy
 1. Give your policy a name. We recommend that organizations create a meaningful standard for the names of their policies.
 1. Under **Assignments**, select **Users or workload identities**.
    1. Under **Include**, select **All users**.
-   1. Under **Exclude**, select **Users and groups** and choose any accounts that must maintain the ability to use legacy authentication.
+   1. Under **Exclude**, select **Users and groups** and choose any accounts that must maintain the ability to use legacy authentication. Microsoft recommends you exclude at least one account to prevent yourself from being locked out.
 1. Under **Target resources** > **Cloud apps** > **Include**, select **All cloud apps**.
 1. Under **Conditions** > **Client apps**, set **Configure** to **Yes**.
    1. Check only the boxes **Exchange ActiveSync clients** and **Other clients**.

--- a/docs/identity/conditional-access/howto-conditional-access-policy-block-legacy.md
+++ b/docs/identity/conditional-access/howto-conditional-access-policy-block-legacy.md
@@ -33,7 +33,7 @@ The following steps will help create a Conditional Access policy to block legacy
 1. Give your policy a name. We recommend that organizations create a meaningful standard for the names of their policies.
 1. Under **Assignments**, select **Users or workload identities**.
    1. Under **Include**, select **All users**.
-   1. Under **Exclude**, select **Users and groups** and choose any accounts that must maintain the ability to use legacy authentication. Exclude at least one account to prevent yourself from being locked out. If you don't exclude any account, you won't be able to create this policy.
+   1. Under **Exclude**, select **Users and groups** and choose any accounts that must maintain the ability to use legacy authentication.
 1. Under **Target resources** > **Cloud apps** > **Include**, select **All cloud apps**.
 1. Under **Conditions** > **Client apps**, set **Configure** to **Yes**.
    1. Check only the boxes **Exchange ActiveSync clients** and **Other clients**.


### PR DESCRIPTION
This line is not necessary as policy is only targetting legacy clients. User would not be blocked from accessing the Entra portal and changing the policy. It is creating confusion with customers as it prevents the tenant secure score from reaching 100% under the "Block legacy authentication" score.