### PR TITLE
Update admin-units-members-dynamic.md

### DIFF
--- a/docs/identity/role-based-access-control/admin-units-members-dynamic.md
+++ b/docs/identity/role-based-access-control/admin-units-members-dynamic.md
@@ -27,7 +27,7 @@ You can add or remove users or devices for administrative units manually. With t
 > [!NOTE]
 > Dynamic membership rules for administrative units can be created using the same attributes available for dynamic groups. For more information about the specific attributes available and examples on how to use them, see [Dynamic membership rules for groups in Microsoft Entra ID](~/identity/users/groups-dynamic-membership.md).
 
-Although administrative units with members assigned manually support multiple object types, such as user, group, and devices, it is currently not possible to create an administrative unit with dynamic membership rules that includes more than one object type. For example, you can create administrative units with dynamic membership rules for users or devices, but not both. Administrative units with dynamic membership rules for groups are currently not supported.
+Although administrative units with members assigned manually support multiple object types, such as user, group, and devices, it is currently not possible to create an administrative unit with dynamic membership rules that includes more than one object type. For example, you can create administrative units with dynamic membership rules for users or devices, but not both.
 
 ## Prerequisites
 


### PR DESCRIPTION
Dynamic Administrative Units support using a membership rule that uses a memberof statement that points to a group. I have removed the sentence that states this is not spported.