### PR TITLE
Clarify the impact of an Entra role scope type

### DIFF
--- a/docs/identity/role-based-access-control/custom-overview.md
+++ b/docs/identity/role-based-access-control/custom-overview.md
@@ -93,6 +93,8 @@ If you specify a Microsoft Entra resource as a scope, it can be one of the follo
 - Enterprise applications
 - Application registrations
 
+When a role is assigned over a scope container, such as the Tenant or an Administrative Unit, it grants permissions over the objects they contain but not on the container itself. On the contrary, when a role is assigned over a resource scope, it grants permissions over the resource itself but it does not extend beyond (in particular, it does not extend to the members of a Microsoft Entra group).
+
 For more information, see [Assign Microsoft Entra roles at different scopes](assign-roles-different-scopes.md).
 
 ## Role assignment options


### PR DESCRIPTION
It's an important distinction to me and I consider it must be highlighted more than buried in another doc page, source: https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/assign-roles-different-scopes#assign-roles-scoped-to-an-app-registration:~:text=The%20scope%20/administrativeUnits/foo%20means%20the%20principal%20can%20manage%20the%20members%20of%20the%20administrative%20unit%20(based%20on%20the%20role%20that%20she%20is%20assigned)%2C%20not%20the%20administrative%20unit%20itself.%20The%20scope%20of%20/foo%20means%20the%20principal%20can%20manage%20that%20Microsoft%20Entra%20object%20itself.%20In