### PR TITLE
Update reset-redemption-status.md

### DIFF
--- a/docs/external-id/reset-redemption-status.md
+++ b/docs/external-id/reset-redemption-status.md
@@ -78,7 +78,6 @@ If a user wants to sign in using a different email:
 
 ```powershell
 Install-Module Microsoft.Graph
-Select-MgProfile -Name v1.0
 Connect-MgGraph -Scopes "User.ReadWrite.All"
 
 $user = Get-MgUser -Filter "startsWith(mail, 'john.doe@fabrikam.net')"


### PR DESCRIPTION
Removing the code snippet/line:

`Select-MgProfile -Name v1.0`

Since Microsoft Graph PowerShell v2 does not require switching profiles.