### PR TITLE
Authentication Strength limitations for Email OTP accounts

### DIFF
--- a/docs/external-id/one-time-passcode.md
+++ b/docs/external-id/one-time-passcode.md
@@ -27,6 +27,10 @@ The email one-time passcode feature is a way to authenticate B2B collaboration u
 >
 > - The email one-time passcode feature is now turned on by default for all new tenants and for any existing tenants where you haven’t explicitly turned it off. This feature provides a seamless fallback authentication method for your guest users. If you don’t want to use this feature, you can [disable it](#enable-or-disable-email-one-time-passcodes), in which case users will be prompted to create a Microsoft account instead.
 
+> [!NOTE]
+> 
+> Currently you cannot apply authentication strength policies via Conditional Access to email one-time passcode accounts. Use the Conditional Access grant control 'Require MFA' instead. For more information, see the [Authentication strength policies for external users](authentication-conditional-access.md#authentication-strength-policies-for-external-users) section of the [Authentication and Conditional Access for External ID](authentication-conditional-access.md) page.
+
 ## Sign-in endpoints
 
 Email one-time passcode guest users can now sign in to your multitenant or Microsoft first-party apps by using a [common endpoint](redemption-experience.md#redemption-process-and-sign-in-through-a-common-endpoint) (in other words, a general app URL that doesn't include your tenant context). During the sign-in process, the guest user chooses **Sign-in options**, and then selects **Sign in to an organization**. The user then types the name of your organization and continues signing in using one-time passcode.


### PR DESCRIPTION
Currently Email OTP support for authentication strength policies is not present, but it is only described in one small note on a separate Conditional Access page - bringing that detail across into the Email OTP page means people are more likely to see this limitation. At the moment, the strange error message that is presented to users provides no explanation for why this behaviour is happening.