### PR TITLE
Update permissions-reference.md

### DIFF
--- a/docs/identity/role-based-access-control/permissions-reference.md
+++ b/docs/identity/role-based-access-control/permissions-reference.md
@@ -233,7 +233,6 @@ For more information, see [Microsoft Defender for Office 365 permissions in the 
 > | Actions | Description |
 > | --- | --- |
 > | microsoft.office365.protectionCenter/attackSimulator/payload/allProperties/allTasks | Create and manage attack payloads in Attack Simulator |
-> | microsoft.office365.protectionCenter/attackSimulator/reports/allProperties/read | Read reports of attack simulation, responses, and associated training |
 
 ## Attack Simulation Administrator
 


### PR DESCRIPTION
Corrected the list of tasks that the attack payload author can do. Relevant reference: https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/attack-simulation-training-get-started?view=o365-worldwide#what-do-you-need-to-know-before-you-begin