### PR TITLE
Update the table for authenticator passwordless

### DIFF
--- a/docs/identity/authentication/concept-authentication-methods.md
+++ b/docs/identity/authentication/concept-authentication-methods.md
@@ -64,7 +64,7 @@ The following table outlines when an authentication method can be used during a 
 |--------------------------------|:----------------------:|:-------------------------:|
 | Windows Hello for Business     | Yes                    | MFA\*                     |
 | Microsoft Authenticator (Push) | No                     | MFA and SSPR              |
-| Microsoft Authenticator (Passwordless) | Yes            | No                        |
+| Microsoft Authenticator (Passwordless) | Yes            | No\*1                     |
 | Authenticator Lite             | No                     | MFA                       |
 | FIDO2 security key             | Yes                    | MFA                       |
 | Certificate-based authentication | Yes                  | MFA                        |
@@ -76,6 +76,9 @@ The following table outlines when an authentication method can be used during a 
 | Password                       | Yes                    | No                        |
 
 > \* Windows Hello for Business, by itself, does not serve as a step-up MFA credential. For example, an MFA Challenge from Sign-in Frequency or SAML Request containing forceAuthn=true. Windows Hello for Business can serve as a step-up MFA credential by being used in FIDO2 authentication. This requires users to be enabled for FIDO2 authentication to work successfully.
+
+> \*1 Only in the scenario of Microsoft Entra certificate-based (CBA) authentication is used as primary authenticaion, Microsoft Authenticator (Passwordless) can be used as secondary authentication. For details, please see this document.
+> [Microsoft Entra certificate-based authentication technical deep dive](https://learn.microsoft.com/en-us/entra/identity/authentication/concept-certificate-based-authentication-technical-deep-dive#mfa-with-single-factor-certificate-based-authentication-preview)
 
 All of these authentication methods can be configured in the Microsoft Entra admin center, and increasingly using the [Microsoft Graph REST API](/graph/api/resources/authenticationmethods-overview).
 


### PR DESCRIPTION
Update the table for authenticator passwordless since it can be used as secondary authentication only when CBA is primary authentication.