### PR TITLE
Update how-to-mfa-server-migration-utility.md

### DIFF
--- a/docs/identity/authentication/how-to-mfa-server-migration-utility.md
+++ b/docs/identity/authentication/how-to-mfa-server-migration-utility.md
@@ -34,7 +34,7 @@ Take a look at our video for an overview of the MFA Server Migration Utility and
 
 - The MFA Server Migration Utility requires a new build of the MFA Server solution to be installed on your Primary MFA Server. The build makes updates to the MFA Server data file, and includes the new MFA Server Migration Utility. You don't have to update the WebSDK or User portal. Installing the update _doesn't_ start the migration automatically.
 >[!NOTE]
-> The MFA Server Migration Utility can be executed on a secondary MFA Server. For more information, please check [Run a secondary MFA Server (optional)](#run-a-secondary-mfa-server-optional)"
+> The MFA Server Migration Utility can be executed on a secondary MFA Server. For more information, please check [Run a secondary MFA Server (optional)](#run-a-secondary-mfa-server-optional).
 
 - The MFA Server Migration Utility copies the data from the database file onto the user objects in Microsoft Entra ID. During migration, users can be targeted for Microsoft Entra multifactor authentication for testing purposes using [Staged Rollout](~/identity/hybrid/connect/how-to-connect-staged-rollout.md). Staged migration lets you test without making any changes to your domain federation settings. Once migrations are complete, you must finalize your migration by making changes to your domain federation settings.
 - AD FS running Windows Server 2016 or higher is required to provide MFA authentication on any AD FS relying parties, not including Microsoft Entra ID and Office 365. 

--- a/docs/identity/authentication/how-to-mfa-server-migration-utility.md
+++ b/docs/identity/authentication/how-to-mfa-server-migration-utility.md
@@ -33,8 +33,9 @@ Take a look at our video for an overview of the MFA Server Migration Utility and
 ## Limitations and requirements
 
 - The MFA Server Migration Utility requires a new build of the MFA Server solution to be installed on your Primary MFA Server. The build makes updates to the MFA Server data file, and includes the new MFA Server Migration Utility. You don't have to update the WebSDK or User portal. Installing the update _doesn't_ start the migration automatically.
->[!NOTE]
-> The MFA Server Migration Utility can be executed on a secondary MFA Server. For more information, please check [Run a secondary MFA Server (optional)](#run-a-secondary-mfa-server-optional).
+
+   > [!NOTE]
+   > The MFA Server Migration Utility can be executed on a secondary MFA Server. For more information, please check [Run a secondary MFA Server (optional)](#run-a-secondary-mfa-server-optional).
 
 - The MFA Server Migration Utility copies the data from the database file onto the user objects in Microsoft Entra ID. During migration, users can be targeted for Microsoft Entra multifactor authentication for testing purposes using [Staged Rollout](~/identity/hybrid/connect/how-to-connect-staged-rollout.md). Staged migration lets you test without making any changes to your domain federation settings. Once migrations are complete, you must finalize your migration by making changes to your domain federation settings.
 - AD FS running Windows Server 2016 or higher is required to provide MFA authentication on any AD FS relying parties, not including Microsoft Entra ID and Office 365. 

--- a/docs/identity/authentication/how-to-mfa-server-migration-utility.md
+++ b/docs/identity/authentication/how-to-mfa-server-migration-utility.md
@@ -33,6 +33,9 @@ Take a look at our video for an overview of the MFA Server Migration Utility and
 ## Limitations and requirements
 
 - The MFA Server Migration Utility requires a new build of the MFA Server solution to be installed on your Primary MFA Server. The build makes updates to the MFA Server data file, and includes the new MFA Server Migration Utility. You don't have to update the WebSDK or User portal. Installing the update _doesn't_ start the migration automatically.
+>[!NOTE]
+> The MFA Server Migration Utility can be executed on a secondary MFA Server. For more information, please check [Run a secondary MFA Server (optional)](#run-a-secondary-mfa-server-optional)"
+
 - The MFA Server Migration Utility copies the data from the database file onto the user objects in Microsoft Entra ID. During migration, users can be targeted for Microsoft Entra multifactor authentication for testing purposes using [Staged Rollout](~/identity/hybrid/connect/how-to-connect-staged-rollout.md). Staged migration lets you test without making any changes to your domain federation settings. Once migrations are complete, you must finalize your migration by making changes to your domain federation settings.
 - AD FS running Windows Server 2016 or higher is required to provide MFA authentication on any AD FS relying parties, not including Microsoft Entra ID and Office 365. 
 - Review your AD FS access control policies and make sure none requires MFA to be performed on-premises as part of the authentication process.


### PR DESCRIPTION
The fact that a secondary MFA Server can be used to execute the migration utility is not mentioned in the section "Limitations and requirements". Based on this we should consider having this clear for future references as it also mentions that this is the best approach considering performance during the migration.