### PR TITLE
Update tutorial-enable-azure-mfa.md

### DIFF
--- a/docs/identity/authentication/tutorial-enable-azure-mfa.md
+++ b/docs/identity/authentication/tutorial-enable-azure-mfa.md
@@ -187,7 +187,7 @@ You configured the Conditional Access policy to require additional authenticatio
 If you no longer want to use the Conditional Access policy that you configured as part of this tutorial, delete the policy by using the following steps:
 
 1. Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com) as at least a [Conditional Access Administrator](~/identity/role-based-access-control/permissions-reference.md#conditional-access-administrator).
-1. Browse to **Protection** > **Conditional Access**, and then select the policy that you created, such as **MFA Pilot**.
+1. Browse to **Policies** > **Conditional Access**, and then select the policy that you created, such as **MFA Pilot**.
 
 1. select **Delete**, and then confirm that you want to delete the policy.
 


### PR DESCRIPTION
The path to the policies in section Clean up resources should contain 'Policies' instead of 'Protection'

Existing:
Browse to Protection > Conditional Access, and then select the policy that you created, such as MFA Pilot.

Should be:
Browse to **Policies>** Conditional Access, and then select the policy that you created, such as MFA Pilot.