### PR TITLE
Change python3 to python

### DIFF
--- a/docs/identity-platform/quickstart-web-app-python-sign-in.md
+++ b/docs/identity-platform/quickstart-web-app-python-sign-in.md
@@ -93,13 +93,13 @@ You can also use an integrated development environment to open the folder.
 1. Install the requirements using `pip`:
 
     ```shell
-    python3 -m pip install -r requirements.txt
+    python -m pip install -r requirements.txt
     ```
 
 2. Run the app from the command line, specifying the host and port to match the redirect URI:
 
     ```shell
-    python3 -m flask run --debug --host=localhost --port=5000
+    python -m flask run --debug --host=localhost --port=5000
     ```
 
    > [!IMPORTANT]


### PR DESCRIPTION
When I edited this tutorial previously, I used "python3" to help developers that might have both "python2" and "python3" on their machines. However, I have since discovered that the "python3" alias is only on Mac's, not Windows machines, so I think it's better to use just "python" (and hope that most folks have moved on from machines that default to Python 2).