### PR TITLE
Update claims-mapping.md

### DIFF
--- a/docs/external-id/claims-mapping.md
+++ b/docs/external-id/claims-mapping.md
@@ -36,9 +36,7 @@ For information about how to add and edit claims, see [Customizing claims issued
 
 ## UPN claims behavior for B2B users
 
-If you need to issue the UPN value as an application token claim, the actual claim mapping may behave differently for B2B users. If the B2B user authenticates with an external Microsoft Entra identity and you issue user.userprincipalname as the source attribute, Microsoft Entra ID instead issues the mail attribute.  
-
-For example, let’s say you invite an external user whose email is `james@contoso.com` and whose identity exists in an external Microsoft Entra tenant. James’ UPN in the inviting tenant is created from the invited email and the inviting tenant's original default domain. So, let’s say James’ UPN becomes `James_contoso.com#EXT#@fabrikam.onmicrosoft.com`. For the SAML application that issues user.userprincipalname as the NameID, the value passed for James is `james@contoso.com`.  
+If you need to issue the UPN value as an application token claim, the actual claim mapping may behave differently for B2B users. If the B2B user authenticates with an external Microsoft Entra identity and you issue user.userprincipalname as the source attribute, Microsoft Entra ID issues the UPN attribute from the home tenant for this user.  
 
 All [other external identity types](redemption-experience.md#invitation-redemption-flow) such as SAML/WS-Fed, Google, Email OTP issues the UPN value rather than the email value when you issue user.userprincipalname as a claim. If you want the actual UPN to be issued in the token claim for all B2B users, you can set user.localuserprincipalname as the source attribute instead. 
 


### PR DESCRIPTION
We verified in test lab that the NameID claim in SAML token is based on UPN of the home tenant for the guest user. So, I created this request.