### PR TITLE
Works only on device with iOS 17

### DIFF
--- a/docs/identity/authentication/concept-fido2-compatibility.md
+++ b/docs/identity/authentication/concept-fido2-compatibility.md
@@ -29,13 +29,15 @@ The following tables lists which authentication brokers are supported for differ
 
 | OS | Authentication broker           | Supports FIDO2 |
 |------------------|---------------------------------|----------------|
-| **iOS**              | Microsoft Authenticator         | &#x2705;       |
-| **macOS**            | Microsoft Intune Company Portal <sup>1</sup> | &#x2705;       |
-| **Android**<sup>2</sup> | Authenticator or Company Portal | &#10060;    |
+| **iOS**<sup>1</sup>              | Microsoft Authenticator         | &#x2705;       |
+| **macOS**            | Microsoft Intune Company Portal <sup>2</sup> | &#x2705;       |
+| **Android**<sup>3</sup> | Authenticator or Company Portal | &#10060;    |
 
-<sup>1</sup>On macOS, the [Microsoft Enterprise Single Sign On (SSO) plug-in](~/identity-platform/apple-sso-plugin.md) is required to enable Company Portal as an authentication broker. Devices that run macOS must meet SSO plug-in requirements, including enrollment in mobile device management. For FIDO2 authentication, make sure that you run the latest version of native applications. 
+<sup>1</sup>An iPhone or iPad running iOS 17 and later.
 
-<sup>2</sup>Native application support for FIDO2 on Android is in development.
+<sup>2</sup>On macOS, the [Microsoft Enterprise Single Sign On (SSO) plug-in](~/identity-platform/apple-sso-plugin.md) is required to enable Company Portal as an authentication broker. Devices that run macOS must meet SSO plug-in requirements, including enrollment in mobile device management. For FIDO2 authentication, make sure that you run the latest version of native applications. 
+
+<sup>3</sup>Native application support for FIDO2 on Android is in development.
 
 If a user installed an authentication broker, they can choose to sign in with a security key when they access an application such as Outlook. They're redirected to sign in with FIDO2, and redirected back to Outlook as a signed in user after successful authentication.
 


### PR DESCRIPTION
Customers have tested sign-in with FIDO on previous versions of iOS and reported that it does not work when trying to sign-in to native apps. After testing we see that it works only on iOS 17 and above.

This could be due to the requirement of iOS 17 for sign in with passkeys and sign-in to native apps makes use of Authenticator as broker.
https://learn.microsoft.com/en-us/entra/identity/authentication/how-to-enable-authenticator-passkey

Kindly confirm the iOS requirement with Product team and update the same in public documentation. 