### PR TITLE
All "Directory Synchronization Accounts" role assignees are excluded from security defaults

### DIFF
--- a/docs/fundamentals/security-defaults.md
+++ b/docs/fundamentals/security-defaults.md
@@ -157,7 +157,7 @@ This policy applies to all users who are accessing Azure Resource Manager servic
 > Pre-2017 Exchange Online tenants have modern authentication disabled by default. In order to avoid the possibility of a login loop while authenticating through these tenants, you must [enable modern authentication](/exchange/clients-and-mobile-in-exchange-online/enable-or-disable-modern-authentication-in-exchange-online).
 
 > [!NOTE]
-> The Microsoft Entra Connect synchronization account is excluded from security defaults and will not be prompted to register for or perform multifactor authentication. Organizations should not be using this account for other purposes.
+> The Microsoft Entra Connect / Microsoft Entra Cloud Sync synchronization accounts (or any security principal assigned to the "Directory Synchronization Accounts" role) are excluded from security defaults and will not be prompted to register for or perform multifactor authentication. Organizations should not be using this account for other purposes.
 
 ## Deployment considerations
 


### PR DESCRIPTION
As highlighted by @DrAzureAD in https://twitter.com/DrAzureAD/status/1531600224711483392 this limitation really concerns all "Directory Synchronization Accounts" role assignees and not only the one expected legitimate account. Also, as explained in this other PR MicrosoftDocs#734, Microsoft Entra Cloud Sync also uses this role.

_Replacing https://github.com/MicrosoftDocs/entra-docs/pull/736_