### PR TITLE
Update permissions-reference.md

### DIFF
--- a/docs/identity/role-based-access-control/permissions-reference.md
+++ b/docs/identity/role-based-access-control/permissions-reference.md
@@ -2729,6 +2729,7 @@ Users with this role **cannot** do the following:
 - Cannot manage MFA.
 - Cannot change the credentials or reset MFA for members and owners of a [role-assignable group](groups-concept.md).
 - Cannot manage shared mailboxes.
+- Cannot modify security questions for password reset operation.
 
 > [!IMPORTANT]
 > Users with this role can change passwords for people who may have access to sensitive or private information or critical configuration inside and outside of Microsoft Entra ID. Changing the password of a user may mean the ability to assume that user's identity and permissions. For example:


### PR DESCRIPTION
It should be clearly stated that User Administrator cannot modify security questions for password reset operation. I've added it.