### PR TITLE
Update custom-security-attributes-overview.md

### DIFF
--- a/docs/fundamentals/custom-security-attributes-overview.md
+++ b/docs/fundamentals/custom-security-attributes-overview.md
@@ -154,7 +154,7 @@ Here are some of the limits and constraints for custom security attributes.
 > | Attribute sets per tenant | 500 |  |
 > | Attribute set name length | 32 | Unicode characters and case insensitive |
 > | Attribute set description length | 128 | Unicode characters |
-> | Attribute name length | 32 | Unicode characters and case insensitive |
+> | Attribute name length | 32 | Unicode characters and case insensitive. However, the combination of attribute set and attribute name is case sensitive in order to form a unique attribute for your tenant. |
 > | Attribute description length | 128 | Unicode characters |
 > | Predefined values |  | Unicode characters and case sensitive |
 > | Predefined values per attribute definition | 100 |  |


### PR DESCRIPTION
from a supportability perspective make it clear that even though Attribute name and AttributeSet name are both case insensitive, however, the combination of these two is case sensitive. This helps developers when using Graph APIs to assign values to them.  Feature 2746414: [DOC]APPX: update public doc to call out the case sensitivity of the custom attribute name combination https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2746414