### PR TITLE
Update Small Improvements description

### DIFF
--- a/docs/identity/saas-apps/smallimprovements-tutorial.md
+++ b/docs/identity/saas-apps/smallimprovements-tutorial.md
@@ -141,15 +141,17 @@ In this section, you'll enable B.Simon to use single sign-on by granting access 
 
     a. Check **Enable SAML for SSO**.
 
-    b. In the **HTTP Endpoint** textbox, paste the value of **Login URL**.
+    b. In the **Application Issuer URL** textbnox enter your Small Improvements subdomain (in the format `https://<yourcompany>.small-improvements.com`
 
-    c. Open your downloaded certificate in Notepad, copy the content, and then paste it into the **x509 Certificate** textbox. 
+    c. In the **HTTP Endpoint** textbox, paste the value of **Login URL**.
 
-    d. If you wish to have SSO and Login form authentication option available for users, then check the **Enable access via login/password too** option.  
+    d. Open your downloaded certificate in Notepad, copy the content, and then paste it into the **x509 Certificate** textbox. 
 
-    e. Enter the appropriate value to Name the SSO Login button in the **SAML Prompt** textbox.  
+    e. If you wish to have SSO and Login form authentication option available for users, then check the **Enable access via login/password too** option.  
 
-    f. Click **Save**.
+    f. Enter the appropriate value to Name the SSO Login button in the **SAML Prompt** textbox.  
+
+    g. Click **Save**.
 
 ### Create Small Improvements test user
 


### PR DESCRIPTION
We found that the Application Issuer URL is required by Azure (customers receive an Azure error during login if it is not present). This change documents what the enter in this field.