### PR TITLE
Disabled users are missing from the "User registration details" report

### DIFF
--- a/docs/identity/authentication/howto-authentication-methods-activity.md
+++ b/docs/identity/authentication/howto-authentication-methods-activity.md
@@ -103,7 +103,7 @@ The **Usage** report shows which authentication methods are used to sign-in and 
 Using the controls at the top of the list, you can search for a user and filter the list of users based on the columns shown.
 
 >[!NOTE]
->User accounts that were recently deleted, also known as [soft-deleted users](~/fundamentals/users-restore.yml), are not listed in user registration details.  
+>User accounts that were recently deleted, also known as [soft-deleted users](~/fundamentals/users-restore.yml), are not listed in user registration details. Same for disabled users.  
 
 The registration details report shows the following information for each user:
 


### PR DESCRIPTION
I actually discovered it when finding discrepancies using this API: https://learn.microsoft.com/en-us/graph/api/authenticationmethodsroot-list-userregistrationdetails?view=graph-rest-beta&tabs=http

But I managed to reproduce it in this menu too. Here's the proof:
![image](https://github.com/MicrosoftDocs/entra-docs/assets/550823/4357766d-cb5d-4876-9a0c-45e7c3462122)
