### PR TITLE
Update slack-provisioning-tutorial.md

### DIFF
--- a/docs/identity/saas-apps/slack-provisioning-tutorial.md
+++ b/docs/identity/saas-apps/slack-provisioning-tutorial.md
@@ -20,6 +20,9 @@ ms.author: Thwimmer
 
 # Tutorial: Configure Slack for automatic user provisioning
 
+> [!NOTE]
+> Integrating with Slack with a custom / BYOA application is not supported. Using the gallery application as described in this tutorial is supported. The gallery application has been customized to work with Slack's SCIM v1 server. 
+
 The objective of this tutorial is to show you the steps you need to perform in Slack and Microsoft Entra ID to automatically provision and de-provision user accounts from Microsoft Entra ID to Slack. For important details on what this service does, how it works, and frequently asked questions, see [Automate user provisioning and deprovisioning to SaaS applications with Microsoft Entra ID](~/identity/app-provisioning/user-provisioning.md). 
 
 


### PR DESCRIPTION
Slack is advising customers to use a non-gallery app with their v2 endpoint however this results in issues disabling users, in other cases when we send the request to remove a member of a group ALL members are removed. 

The scim flag fixes the membership issue however the app still doesn't disable users. 

I believe we should add this note advising customers to use the gallery app for now until Slack reaches out to our team to update this gallery app to scim v2