### PR TITLE
Remove the reference to EMU beta

### DIFF
--- a/docs/identity/saas-apps/github-enterprise-managed-user-provisioning-tutorial.md
+++ b/docs/identity/saas-apps/github-enterprise-managed-user-provisioning-tutorial.md
@@ -33,9 +33,6 @@ This tutorial describes the steps you need to perform in both GitHub Enterprise 
 > * Provision groups and group memberships in GitHub Enterprise Managed User
 > * Single sign-on to GitHub Enterprise Managed User (recommended)
 
-> [!NOTE]
-> This provisioning connector is enabled only for Enterprise Managed Users beta participants.
-
 
 ## Prerequisites
 


### PR DESCRIPTION
This pull request includes a small change to the `docs/identity/saas-apps/github-enterprise-managed-user-provisioning-tutorial.md` file. The change removes a note stating that the provisioning connector is only enabled for Enterprise Managed Users beta participants. EMUs has been out of beta for a while already.