### PR TITLE
Migrate to Docker Compose v2, avoid hardcoding secrets

### DIFF
--- a/docs/identity/enterprise-apps/datawiza-configure-sha.md
+++ b/docs/identity/enterprise-apps/datawiza-configure-sha.md
@@ -78,25 +78,32 @@ To get started, you need:
    ```yaml
    services:
       datawiza-access-broker:
-      image: registry.gitlab.com/datawiza/access-broker
-      container_name: datawiza-access-broker
-      restart: always
-      ports:
-      - "9772:9772"
-      environment:
-      PROVISIONING_KEY: #############################################
-      PROVISIONING_SECRET: ##############################################
-      
+         image: registry.gitlab.com/datawiza/access-broker
+         container_name: datawiza-access-broker
+         restart: always
+         ports:
+            - "9772:9772"
+         environment:
+            PROVISIONING_KEY: ${PROVISIONING_KEY:?}
+            PROVISIONING_SECRET: ${PROVISIONING_SECRET:?}
+
       header-based-app:
-      image: registry.gitlab.com/datawiza/header-based-app
-      restart: always
-   ports:
-   - "3001:3001"
+         image: registry.gitlab.com/datawiza/header-based-app
+         restart: always
+         ports:
+            - "3001:3001"
+   ```
+
+    - Set **PROVISIONING_KEY** and **PROVISIONING_SECRET** using an `.env` file placed at the base of your project directory.
+
+   ```bash
+   PROVISIONING_KEY=replace-with-your-PROVISIONING-KEY
+   PROVISIONING_SECRET=replace-with-your-PROVISIONING-SECRET
    ```
 
 7. Sign in to the container registry.
 8. Download the DAP images and the header-based application in this [Important Step](https://docs.datawiza.com/step-by-step/step3.html#important-step).
-9. Run the following command: `docker-compose -f docker-compose.yml up`.
+9. Run the following command: `docker compose -f docker-compose.yml up`.
 10. The header-based application has SSO enabled with Microsoft Entra ID.
 11. In a browser, go to `http://localhost:9772/`. 
 12. A Microsoft Entra sign-in page appears.

--- a/docs/identity/enterprise-apps/datawiza-configure-sha.md
+++ b/docs/identity/enterprise-apps/datawiza-configure-sha.md
@@ -94,7 +94,7 @@ To get started, you need:
             - "3001:3001"
    ```
 
-    - Set **PROVISIONING_KEY** and **PROVISIONING_SECRET** using an `.env` file placed at the base of your project directory.
+  - Set **PROVISIONING_KEY** and **PROVISIONING_SECRET** using an `.env` file placed at the base of your project directory.
 
    ```bash
    PROVISIONING_KEY=replace-with-your-PROVISIONING-KEY


### PR DESCRIPTION
I updated the Datawiza Access Broker docs to use Docker Compose v2 (`docker compose`), since the Compose v1 command (`docker-compose`) was [deprecated in July 2023](https://docs.docker.com/compose/migrate). 

Additionally, I adjusted the example to correct the invalid YAML indentation, and avoid hardcoding secrets directly into the Docker Compose file, recommending an env file instead.