### PR TITLE
Add two-way forest trust support to feature comparison table

### DIFF
--- a/docs/identity/domain-services/compare-identity-solutions.md
+++ b/docs/identity/domain-services/compare-identity-solutions.md
@@ -70,7 +70,7 @@ The following table outlines some of the features you may need for your organiza
 | **Custom OU structure**                           | **&#x2713;** | **&#x2713;** |
 | **Group Policy**                                  | **&#x2713;** | **&#x2713;** |
 | **Schema extensions**                             | **&#x2715;** | **&#x2713;** |
-| **AD domain / forest trusts**                     | **&#x2713;** (one-way outbound forest trusts only) | **&#x2713;** |
+| **AD domain / forest trusts**                     | **&#x2713;** (one-way and two-way trusts) | **&#x2713;** |
 | **Secure LDAP (LDAPS)**                           | **&#x2713;** | **&#x2713;** |
 | **LDAP read**                                     | **&#x2713;** | **&#x2713;** |
 | **LDAP write**                                    | **&#x2713;** (within the managed domain) | **&#x2713;** |

--- a/docs/identity/domain-services/compare-identity-solutions.md
+++ b/docs/identity/domain-services/compare-identity-solutions.md
@@ -70,7 +70,7 @@ The following table outlines some of the features you may need for your organiza
 | **Custom OU structure**                           | **&#x2713;** | **&#x2713;** |
 | **Group Policy**                                  | **&#x2713;** | **&#x2713;** |
 | **Schema extensions**                             | **&#x2715;** | **&#x2713;** |
-| **AD domain / forest trusts**                     | **&#x2713;** (one-way and two-way trusts) | **&#x2713;** |
+| **AD domain / forest trusts**                     | **&#x2713;** (one-way outbound and two-way trusts) | **&#x2713;** |
 | **Secure LDAP (LDAPS)**                           | **&#x2713;** | **&#x2713;** |
 | **LDAP read**                                     | **&#x2713;** | **&#x2713;** |
 | **LDAP write**                                    | **&#x2713;** (within the managed domain) | **&#x2713;** |


### PR DESCRIPTION
Closes #908

Indicate support for two-way forest trust on the managed domains feature comparison table.