### PR TITLE
Improve wording of oauth2 request

### DIFF
--- a/docs/identity-platform/v2-oauth2-auth-code-flow.md
+++ b/docs/identity-platform/v2-oauth2-auth-code-flow.md
@@ -56,7 +56,7 @@ Applications can't use a `spa` redirect URI with non-SPA flows, for example, nat
 
 ## Request an authorization code
 
-The authorization code flow begins with the client directing the user to the `/authorize` endpoint. In this request, the client requests the `openid`, `offline_access`, and `https://graph.microsoft.com/mail.read` permissions from the user.
+The authorization code flow begins with the client directing the user to the `/authorize` endpoint. In this example request, the client requests the `openid`, `offline_access`, and `https://graph.microsoft.com/mail.read` permissions from the user.
 
 Some permissions are admin-restricted, for example, writing data to an organization's directory by using `Directory.ReadWrite.All`. If your application requests access to one of these permissions from an organizational user, the user receives an error message that says they're not authorized to consent to your app's permissions. To request access to admin-restricted scopes, you should request them directly from a Global Administrator. For more information, see [Admin-restricted permissions](./scopes-oidc.md#admin-restricted-permissions).
 


### PR DESCRIPTION
Improve wording of oauth2 request - on my first take I thought it was mandatory to request the `https://graph.microsoft.com/mail.read` permission, while this is just an example.