### PR TITLE
Update claims-customization-powershell.md adding the Policy.Read.All permission to the Connect-MgGraph

### DIFF
--- a/docs/identity-platform/claims-customization-powershell.md
+++ b/docs/identity-platform/claims-customization-powershell.md
@@ -45,7 +45,7 @@ Open a terminal and run the following command to sign in to your Microsoft Entra
 ```PowerShell
 Import-Module Microsoft.Graph.Identity.SignIns
 
-Connect-MgGraph -Scopes "Policy.ReadWrite.ApplicationConfiguration"
+Connect-MgGraph -Scopes "Policy.ReadWrite.ApplicationConfiguration", "Policy.Read.All"
 ```
 
 Now you can create a claims mapping policy and assign it to a service principal. Refer to the following examples for common scenarios:


### PR DESCRIPTION
Add Policy.Read.All permission in the Connect-MgGraph due to a [known issue](https://developer.microsoft.com/en-us/graph/known-issues/?search=13678)

The Policy.Read.All permission is required to run the Get-MgPolicyClaimMappingPolicy and get the claim mapping policy objectId.