### PR TITLE
Update service-accounts-group-managed.md

### DIFF
--- a/docs/architecture/service-accounts-group-managed.md
+++ b/docs/architecture/service-accounts-group-managed.md
@@ -1,7 +1,7 @@
 ---
 title: Secure group managed service accounts
 description: A guide to securing group managed service accounts (gMSAs)
-author: jricketts
+author: janicericketts
 manager: martinco
 ms.service: entra
 ms.subservice: architecture

--- a/docs/architecture/service-accounts-group-managed.md
+++ b/docs/architecture/service-accounts-group-managed.md
@@ -48,18 +48,6 @@ gMSAs are more secure than standard user accounts, which require ongoing passwor
 
 ## Find gMSAs
 
-Your organization might have gMSAs. To retrieve these accounts, run the following PowerShell cmdlets:
-
-```powershell
-Get-ADServiceAccount 
-Install-ADServiceAccount 
-New-ADServiceAccount 
-Remove-ADServiceAccount 
-Set-ADServiceAccount 
-Test-ADServiceAccount 
-Uninstall-ADServiceAccount
-```
-
 ### Managed Service Accounts container
   
 To work effectively, gMSAs must be in the Managed Service Accounts container.


### PR DESCRIPTION
Removed subsection with list of PowerShell cmdlets that are also listed just below. In the removed section we referred to ALL gMSA administrative cmdlets as ways of "finding" a gMSA, yet they do much more than that. Further down in the section, we list all the same cmdlets as methods of "managing" gMSA's, which is correct.