### PR TITLE
rename Esign to SharePoint eSignature

### DIFF
--- a/docs/identity/conditional-access/reference-office-365-application-contents.md
+++ b/docs/identity/conditional-access/reference-office-365-application-contents.md
@@ -23,7 +23,6 @@ The following list is provided as a reference and includes a detailed list of se
 - Connectors
 - Device Management Service
 - EnrichmentSvc
-- ESign
 - IC3 Gateway
 - M365 Admin Services
 - M365 Auditing Public Protected Web API app
@@ -107,6 +106,7 @@ The following list is provided as a reference and includes a detailed list of se
 - ProjectWorkManagement_USGov
 - Reply at mention
 - Security & Compliance Center
+- SharePoint eSignature
 - SharePoint Online Web Client Extensibility
 - SharePoint Online Web Client Extensibility Isolated
 - Skype and Teams Tenant Admin API


### PR DESCRIPTION
Renaming Esign to SharePoint eSignature as the name of this service has changed. Also moved it to the correct position in alphabetic order.