### PR TITLE
Remove -AuthorizationPolicyId which doesn't exist (anymore?)

### DIFF
--- a/docs/identity/enterprise-apps/configure-user-consent.md
+++ b/docs/identity/enterprise-apps/configure-user-consent.md
@@ -76,7 +76,7 @@ $body = @{
         "managePermissionGrantsForOwnedResource.{other-current-policies}" 
     )
 }
-Update-MgPolicyAuthorizationPolicy -AuthorizationPolicyId authorizationPolicy -BodyParameter $body
+Update-MgPolicyAuthorizationPolicy -BodyParameter $body
 
 ```
 
@@ -91,7 +91,7 @@ $body = @{
         "managePermissionGrantsForOwnedResource.{other-current-policies}"
     )
 }
-Update-MgPolicyAuthorizationPolicy -AuthorizationPolicyId authorizationPolicy -BodyParameter $body
+Update-MgPolicyAuthorizationPolicy -BodyParameter $body
 ```
 
 Replace `{consent-policy-id}` with the ID of the policy you want to apply. You can choose a [custom app consent policy](manage-app-consent-policies.md#create-a-custom-app-consent-policy-using-powershell) that you've created, or you can choose from the following built-in policies:


### PR DESCRIPTION
This parameter doesn't exist. At least in the latest v1.0 version of the Graph PowerShell module. Perhaps it used to exist?
Proof in doc: https://learn.microsoft.com/en-us/powershell/module/microsoft.graph.identity.signins/update-mgpolicyauthorizationpolicy?view=graph-powershell-1.0
And in this error:
```
PS> Update-MgPolicyAuthorizationPolicy -AuthorizationPolicyId $authorization_policy -BodyParameter $body
Update-MgPolicyAuthorizationPolicy : A parameter cannot be found that matches parameter name 'AuthorizationPolicyId'.

PS> Get-InstalledModule Microsoft.Graph

Version              Name                                Repository           Description
-------              ----                                ----------           -----------
2.19.0               Microsoft.Graph                     PSGallery            Microsoft Graph PowerShell module
```


Edit: Actually! It exists, but only for the beta version!
https://learn.microsoft.com/en-us/powershell/module/Microsoft.Graph.Beta.Identity.SignIns/Update-MgBetaPolicyAuthorizationPolicy?view=graph-powershell-beta

There are significant differences between the v1.0 and beta versions of this API (returning an object vs. array, authorization policy under `defaultUserRolePermissions.permissionGrantPoliciesAssigned` vs. `permissionGrantPolicyIdsAssignedToDefaultUserRole`)

Currently all the content in the page refers to the beta version of the API and the commands. My advice is to either adapt it to v1.0, or keep beta but make it very explicit and use instead `Update-MgBetaPolicyAuthorizationPolicy`