### PR TITLE
Update zendesk-tutorial.md

### DIFF
--- a/docs/identity/saas-apps/zendesk-tutorial.md
+++ b/docs/identity/saas-apps/zendesk-tutorial.md
@@ -84,7 +84,7 @@ Follow these steps to enable Microsoft Entra SSO.
     `https://<subdomain>.zendesk.com`
 
     b. In the **Identifier (Entity ID)** text box, type a URL using the following pattern:
-    `https://<subdomain>.zendesk.com`
+    `<subdomain>.zendesk.com`
 
     c. In the **Reply URL** text box, type a URL using the following pattern: `https://<subdomain>.zendesk.com/access/saml`
 


### PR DESCRIPTION
Using a URL with https:// does not seem to work. We got an AADSTS650056 error. Omitting https:// makes it work.

Refer to the [SAML configuration page](https://support.zendesk.com/hc/en-us/articles/4408887505690-Enabling-SAML-single-sign-on?per_page=30&page=2#comments) comment section for multiple people commenting about this, and a comment by a Zendesk customer care agent suggesting the solution.