### PR TITLE
Update nulab-pass-tutorial.md

### DIFF
--- a/docs/identity/saas-apps/nulab-pass-tutorial.md
+++ b/docs/identity/saas-apps/nulab-pass-tutorial.md
@@ -1,6 +1,6 @@
 ---
-title: 'Tutorial: Microsoft Entra single sign-on (SSO) integration with Nulab Pass (Backlog,Cacoo,Typetalk)'
-description: Learn how to configure single sign-on between Microsoft Entra ID and Nulab Pass (Backlog,Cacoo,Typetalk).
+title: 'Tutorial: Microsoft Entra single sign-on (SSO) integration with Nulab Pass (Backlog, Cacoo, and Typetalk)'
+description: Learn how to configure single sign-on between Microsoft Entra ID and Nulab Pass (Backlog, Cacoo, and Typetalk).
 
 author: jeevansd
 manager: CelesteDG
@@ -13,94 +13,103 @@ ms.date: 03/25/2024
 ms.author: jeedes
 
 
-# Customer intent: As an IT administrator, I want to learn how to configure single sign-on between Microsoft Entra ID and Nulab Pass (Backlog,Cacoo,Typetalk) so that I can control who has access to Nulab Pass (Backlog,Cacoo,Typetalk), enable automatic sign-in with Microsoft Entra accounts, and manage my accounts in one central location.
+# Customer intent: As an IT administrator, I want to learn how to configure single sign-on between Microsoft Entra ID and Nulab Pass (Backlog, Cacoo, and Typetalk) so that I can control who has access to Nulab Pass (Backlog, Cacoo, and Typetalk), enable automatic sign-in with Microsoft Entra accounts, and manage my accounts in one central location.
 ---
 
-# Tutorial: Microsoft Entra single sign-on (SSO) integration with Nulab Pass (Backlog,Cacoo,Typetalk)
+# Tutorial: Microsoft Entra single sign-on (SSO) integration with Nulab Pass (Backlog, Cacoo, and Typetalk)
 
-In this tutorial, you'll learn how to integrate Nulab Pass (Backlog,Cacoo,Typetalk) with Microsoft Entra ID. When you integrate Nulab Pass (Backlog,Cacoo,Typetalk) with Microsoft Entra ID, you can:
+In this tutorial, you'll learn how to integrate Nulab Pass (Backlog, Cacoo, and Typetalk) with Microsoft Entra ID. By integrating, you can:
 
-* Control in Microsoft Entra ID who has access to Nulab Pass (Backlog,Cacoo,Typetalk).
-* Enable your users to be automatically signed-in to Nulab Pass (Backlog,Cacoo,Typetalk) with their Microsoft Entra accounts.
+* Control who has access to Nulab Pass in Microsoft Entra ID.
+* Enable users to be automatically signed in to Nulab Pass with their Microsoft Entra accounts.
 * Manage your accounts in one central location.
 
 ## Prerequisites
 
-To get started, you need the following items:
+To get started, you need:
 
-* A Microsoft Entra subscription. If you don't have a subscription, you can get a [free account](https://azure.microsoft.com/free/).
-* Nulab Pass (Backlog,Cacoo,Typetalk) single sign-on (SSO) enabled subscription.
+* A Microsoft Entra subscription or [free account](https://azure.microsoft.com/free/).
+* Nulab Pass SSO-enabled subscription.
 
 ## Scenario description
 
-In this tutorial, you configure and test Microsoft Entra SSO in a test environment.
+In this tutorial, you’ll configure and test Microsoft Entra SSO in a test environment. Nulab Pass supports **SP- and IDP**-initiated SSO.
 
-* Nulab Pass (Backlog,Cacoo,Typetalk) supports **SP and IDP** initiated SSO.
+## Add Nulab Pass from the gallery
 
-## Add Nulab Pass (Backlog,Cacoo,Typetalk) from the gallery
-
-To configure the integration of Nulab Pass (Backlog,Cacoo,Typetalk) into Microsoft Entra ID, you need to add Nulab Pass (Backlog,Cacoo,Typetalk) from the gallery to your list of managed SaaS apps.
+To configure the integration of Nulab Pass into Microsoft Entra ID, add Nulab Pass from the gallery to your list of managed SaaS apps.
 
 1. Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com) as at least a [Cloud Application Administrator](~/identity/role-based-access-control/permissions-reference.md#cloud-application-administrator).
-1. Browse to **Identity** > **Applications** > **Enterprise applications** > **New application**.
-1. In the **Add from the gallery** section, type **Nulab Pass (Backlog,Cacoo,Typetalk)** in the search box.
-1. Select **Nulab Pass (Backlog,Cacoo,Typetalk)** from results panel and then add the app. Wait a few seconds while the app is added to your tenant.
+1. Go to **Identity** > **Applications** > **Enterprise applications** > **New application**.
+1. In the **Add from the gallery** section, type **Nulab Pass** in the search box.
+1. Select **Nulab Pass** from results panel and add the app.
+1. Wait a few seconds while the app is added to your tenant.
 
- Alternatively, you can also use the [Enterprise App Configuration Wizard](https://portal.office.com/AdminPortal/home?Q=Docs#/azureadappintegration). In this wizard, you can add an application to your tenant, add users/groups to the app, assign roles, as well as walk through the SSO configuration as well. [Learn more about Microsoft 365 wizards.](/microsoft-365/admin/misc/azure-ad-setup-guides)
+ Alternatively, you can use the [Enterprise App Configuration Wizard](https://portal.office.com/AdminPortal/home?Q=Docs#/azureadappintegration). In this wizard, you can add an application to your tenant, add users/groups to the app, assign roles, and walk through the SSO configuration. [Learn more about Microsoft 365 wizards.](/microsoft-365/admin/misc/azure-ad-setup-guides)
 
 <a name='configure-and-test-azure-ad-sso-for-nulab-pass-backlogcacootypetalk'></a>
 
-## Configure and test Microsoft Entra SSO for Nulab Pass (Backlog,Cacoo,Typetalk)
+## Configure and test Microsoft Entra SSO for Nulab Pass
 
-Configure and test Microsoft Entra SSO with Nulab Pass (Backlog,Cacoo,Typetalk) using a test user called **B.Simon**. For SSO to work, you need to establish a link relationship between a Microsoft Entra user and the related user in Nulab Pass (Backlog,Cacoo,Typetalk).
+Configure and test Microsoft Entra SSO with Nulab Pass using a test user called B.Simon. For SSO to work, you need to establish a link relationship between a Microsoft Entra user and the related user in Nulab Pass.
 
-To configure and test Microsoft Entra SSO with Nulab Pass (Backlog,Cacoo,Typetalk), perform the following steps:
+To configure and test Microsoft Entra SSO with Nulab Pass:
 
-1. **[Configure Microsoft Entra SSO](#configure-azure-ad-sso)** - to enable your users to use this feature.
-    1. **[Create a Microsoft Entra test user](#create-an-azure-ad-test-user)** - to test Microsoft Entra single sign-on with B.Simon.
-    1. **[Assign the Microsoft Entra test user](#assign-the-azure-ad-test-user)** - to enable B.Simon to use Microsoft Entra single sign-on.
-1. **[Configure Nulab Pass SSO](#configure-nulab-pass-sso)** - to configure the single sign-on settings on application side.
-    1. **[Create Nulab Pass test user](#create-nulab-pass-test-user)** - to have a counterpart of B.Simon in Nulab Pass (Backlog,Cacoo,Typetalk) that is linked to the Microsoft Entra representation of user.
-1. **[Test SSO](#test-sso)** - to verify whether the configuration works.
+1. **[Configure Microsoft Entra SSO](#configure-azure-ad-sso)** to enable your users to use this feature.
+    1. **[Create a Microsoft Entra test user](#create-an-azure-ad-test-user)** to test Microsoft Entra SSO with B.Simon.
+    1. **[Assign the Microsoft Entra test user](#assign-the-azure-ad-test-user)** to enable B.Simon to use Microsoft Entra SSO.
+1. **[Configure Nulab Pass SSO](#configure-nulab-pass-sso)** to configure the SSO settings on the application side.
+    1. **[Create Nulab Pass test user](#create-nulab-pass-test-user)** to have a counterpart of B.Simon in Nulab Pass that’s linked to the Microsoft Entra representation of user.
+1. **[Test SSO](#test-sso)** to verify whether the configuration works.
 
 <a name='configure-azure-ad-sso'></a>
 
 ## Configure Microsoft Entra SSO
 
-Follow these steps to enable Microsoft Entra SSO.
+To enable Microsoft Entra SSO:
 
 1. Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com) as at least a [Cloud Application Administrator](~/identity/role-based-access-control/permissions-reference.md#cloud-application-administrator).
-1. Browse to **Identity** > **Applications** > **Enterprise applications** > **Nulab Pass (Backlog,Cacoo,Typetalk)** > **Single sign-on**.
+1. Go to **Identity** > **Applications** > **Enterprise applications** > **Nulab Pass (Backlog,Cacoo,Typetalk)** > **Single sign-on**.
 1. On the **Select a single sign-on method** page, select **SAML**.
-1. On the **Set up single sign-on with SAML** page, click the pencil icon for **Basic SAML Configuration** to edit the settings.
+1. On the **Set up single sign-on with SAML** page, select the pencil icon for **Basic SAML Configuration** to edit the settings.
 
    ![Edit Basic SAML Configuration](common/edit-urls.png)
 
-1. On the **Basic SAML Configuration** section, if you wish to configure the application in **IDP** initiated mode, perform the following steps:
+1. If you want to configure the application in **IDP** initiated mode, complete the following in the **Basic SAML Configuration** section:
 
     a. In the **Identifier** text box, type a URL using the following pattern:
+   
     `https://apps.nulab.com/signin/spaces/<Space Key>/saml`
 
     b. In the **Reply URL** text box, type a URL using the following pattern:
+   
     `https://apps.nulab.com/signin/spaces/<Space Key>/saml/callback`
 
-1. Click **Set additional URLs** and perform the following step if you wish to configure the application in **SP** initiated mode:
+1. Click **Set additional URLs** and perform the following to configure the application in **SP** initiated mode:
 
     In the **Sign-on URL** text box, type a URL using the following pattern:
-    `https://apps.nulab.com/signin/spaces/<INSTANCE_NAME>`
+   
+    `https://apps.nulab.com/signin`
 
 	> [!NOTE]
-	> These values are not real. Update these values with the actual Identifier, Reply URL and Sign-on URL. Contact [Nulab Pass (Backlog,Cacoo,Typetalk) Client support team](mailto:support@apps.nulab.com) to get these values. You can also refer to the patterns shown in the **Basic SAML Configuration** section.
+	> These values are not real and should be updated with the actual Identifier, Reply URL, and Sign-on URL found in your Nulab Pass organization settings. In your organization settings:
+	>  1. Select **Single Sign-On** from the menu on the left.
+ 	>  2. Press the **Manage** button to display the **Manage SAML authentication** dialog.
+	>  3. Use the following values:
+ 	>  	* SP Entity ID 	
+ 	>  	* SP Endpoint URL (ACS)
+	>
+ 	> Learn [how to set up SAML authentication](https://support.nulab.com/hc/en-us/articles/6478805477401).	
 
-1. Your Nulab Pass (Backlog,Cacoo,Typetalk) application expects the SAML assertions in a specific format, which requires you to add custom attribute mappings to your SAML token attributes configuration. The following screenshot shows an example for this. The default value of **Unique User Identifier** is **user.userprincipalname** but Nulab Pass (Backlog,Cacoo,Typetalk) expects this to be mapped with the user's email address. For that you can use **user.mail** attribute from the list or use the appropriate attribute value based on your organization configuration.
+1. Your Nulab Pass application expects the SAML assertions in a specific format, which requires you to add custom attribute mappings to your SAML token attributes configuration. The following screenshot shows an example for this. The default value of **Unique User Identifier** is **user.userprincipalname**, but Nulab Pass expects this to be mapped with the user's email. Use the **user.mail** attribute from the list or the appropriate attribute value based on your organization configuration.
 
 	![image](common/default-attributes.png)
 
-1. On the **Set up single sign-on with SAML** page, in the **SAML Signing Certificate** section,  find **Certificate (Base64)** and select **Download** to download the certificate and save it on your computer.
+1. On the **Set up single sign-on with SAML** page in the **SAML Signing Certificate** section, you’ll find the **Certificate (Base64)**. Select **Download** to download the certificate and save it on your computer.
 
 	![The Certificate download link](common/certificatebase64.png)
 
-1. On the **Set up Nulab Pass (Backlog,Cacoo,Typetalk)** section, copy the appropriate URL(s) based on your requirement.
+1. In the **Set up Nulab Pass** section, copy the appropriate URL(s) based on your requirement.
 
 	![Copy configuration URLs](common/copy-configuration-urls.png)
 
@@ -111,12 +120,12 @@ Follow these steps to enable Microsoft Entra SSO.
 In this section, you'll create a test user called B.Simon.
 
 1. Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com) as at least a [User Administrator](~/identity/role-based-access-control/permissions-reference.md#user-administrator).
-1. Browse to **Identity** > **Users** > **All users**.
+1. Go to **Identity** > **Users** > **All users**.
 1. Select **New user** > **Create new user**, at the top of the screen.
-1. In the **User** properties, follow these steps:
-   1. In the **Display name** field, enter `B.Simon`.  
-   1. In the **User principal name** field, enter the username@companydomain.extension. For example, `B.Simon@contoso.com`.
-   1. Select the **Show password** check box, and then write down the value that's displayed in the **Password** box.
+1. In the **User** properties
+   1. Ener `B.Simon` in the **Display name** field.  
+   1. Enter the username@companydomain.extension in the **User principal name** field. (E.g., `B.Simon@contoso.com`).
+   1. Select the **Show password** check box and write down the value displayed in the **Password** box.
    1. Select **Review + create**.
 1. Select **Create**.
 
@@ -124,40 +133,52 @@ In this section, you'll create a test user called B.Simon.
 
 ### Assign the Microsoft Entra test user
 
-In this section, you'll enable B.Simon to use single sign-on by granting access to Nulab Pass (Backlog,Cacoo,Typetalk).
+In this section, you'll enable B.Simon to use SSO by granting access to Nulab Pass.
 
 1. Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com) as at least a [Cloud Application Administrator](~/identity/role-based-access-control/permissions-reference.md#cloud-application-administrator).
-1. Browse to **Identity** > **Applications** > **Enterprise applications** > **Nulab Pass (Backlog,Cacoo,Typetalk)**.
+1. Go to **Identity** > **Applications** > **Enterprise applications** > **Nulab Pass**.
 1. In the app's overview page, select **Users and groups**.
-1. Select **Add user/group**, then select **Users and groups** in the **Add Assignment** dialog.
-   1. In the **Users and groups** dialog, select **B.Simon** from the Users list, then click the **Select** button at the bottom of the screen.
-   1. If you are expecting a role to be assigned to the users, you can select it from the **Select a role** dropdown. If no role has been set up for this app, you see "Default Access" role selected.
+1. Select **Add user/group** and then **Users and groups** in the **Add Assignment** dialog.
+   1. In the **Users and groups** dialog, select **B.Simon** from the users list and then the **Select** button at the bottom of the screen.
+   1. If you’re expecting users to be assigned a role, select it from the **Select a role** dropdown. If no role has been set up for this app, **Default Access** role is selected.
    1. In the **Add Assignment** dialog, click the **Assign** button.
 
 ## Configure Nulab Pass SSO
 
-To configure single sign-on on **Nulab Pass (Backlog,Cacoo,Typetalk)** side, you need to send the downloaded **Certificate (Base64)** and appropriate copied URLs from the application configuration to [Nulab Pass (Backlog,Cacoo,Typetalk) support team](mailto:support@apps.nulab.com). They set this setting to have the SAML SSO connection set properly on both sides.
+* You must configure **[Domain authentication](https://support.nulab.com/hc/en-us/articles/6558108028825)** before configure SSO.
+
+To configure SSO in **Nulab Pass**, set the **Certificate (Base64)** and URLs from the application configuration to ensure that the SSO connection is set on both sides. To do this:
+
+1. Go to your Nulab Pass organization settings.
+2. Select **Single Sign-On** from the menu on the left.
+3. Press the **Manage** button to display the **Manage SAML authentication** dialog.
+4. Enter the following:
+   * IdP Entity ID
+   * IdP Endpoint URL
+   * X.509 Certificate (Base64)
+
+Learn [how to set up SAML authentication](https://support.nulab.com/hc/en-us/articles/6478805477401).
 
 ### Create Nulab Pass test user
 
-In this section, you create a user called Britta Simon in Nulab Pass (Backlog,Cacoo,Typetalk). Work with [Nulab Pass (Backlog,Cacoo,Typetalk) support team](mailto:support@apps.nulab.com) to add the users in the Nulab Pass (Backlog,Cacoo,Typetalk) platform. Users must be created and activated before you use single sign-on.
+Next, you’ll create a user called `Britta Simon` in Nulab Pass by [adding a Managed Account](https://support.nulab.com/hc/en-us/articles/6480291067801). Users must be created and activated before you use SSO.
 
 ## Test SSO 
 
-In this section, you test your Microsoft Entra single sign-on configuration with following options. 
+Now, you’ll test your Microsoft Entra SSO configuration using one of the following options: 
 
 #### SP initiated:
 
-* Click on **Test this application**, this will redirect to Nulab Pass (Backlog,Cacoo,Typetalk) Sign on URL where you can initiate the login flow.  
+* Click on **Test this application** to be redirected to Nulab Pass to sign in.  
 
-* Go to Nulab Pass (Backlog,Cacoo,Typetalk) Sign-on URL directly and initiate the login flow from there.
+* Or, go to the Nulab Pass sign in page directly and initiate the flow from there.
 
 #### IDP initiated:
 
-* Click on **Test this application**, and you should be automatically signed in to the Nulab Pass (Backlog,Cacoo,Typetalk) for which you set up the SSO. 
+* Click on **Test this application** to be automatically signed in to SSO-enabled Nulab Pass. 
 
-You can also use Microsoft My Apps to test the application in any mode. When you click the Nulab Pass (Backlog,Cacoo,Typetalk) tile in the My Apps, if configured in SP mode you would be redirected to the application sign on page for initiating the login flow and if configured in IDP mode, you should be automatically signed in to the Nulab Pass (Backlog,Cacoo,Typetalk) for which you set up the SSO. For more information about the My Apps, see [Introduction to the My Apps](https://support.microsoft.com/account-billing/sign-in-and-start-apps-from-the-my-apps-portal-2f3b1bae-0e5a-4a86-a33e-876fbd2a4510).
+You can also use Microsoft My Apps to test the application in any mode. When you click the Nulab Pass tile in My Apps, you’ll be redirected to the application sign on page for initiating the login flow if it was configured in SP mode. If configured in IDP mode, you’ll be automatically signed in to SSO-enabled Nulab Pass. [Learn more about My Apps](https://support.microsoft.com/account-billing/sign-in-and-start-apps-from-the-my-apps-portal-2f3b1bae-0e5a-4a86-a33e-876fbd2a4510).
 
 ## Next steps
 
-Once you configure Nulab Pass (Backlog,Cacoo,Typetalk) you can enforce session control, which protects exfiltration and infiltration of your organization’s sensitive data in real time. Session control extends from Conditional Access. [Learn how to enforce session control with Microsoft Defender for Cloud Apps](/cloud-app-security/proxy-deployment-aad).
+With Nulab Pass configured, you can enforce session control, which protects exfiltration and infiltration of your organization’s sensitive data in real time. Session control extends from Conditional Access. [Learn how to enforce session control with Microsoft Defender for Cloud Apps](/cloud-app-security/proxy-deployment-aad).


### PR DESCRIPTION
1. Remove the procedure for contacting the support team and replace it with a procedure whereby the configurator themself sets up the configuration from the Nulab Pass organization management page.
2. Change the Sign-on URL