### PR TITLE
Update sample script

### DIFF
--- a/docs/identity/app-proxy/scripts/powershell-get-custom-domain-identical-cert.md
+++ b/docs/identity/app-proxy/scripts/powershell-get-custom-domain-identical-cert.md
@@ -75,9 +75,10 @@ Write-Host " "
 
 foreach ($item in $allApps) {
 
- $aadapApp, $aadapAppConf, $aadapAppConf1 = $null, $null, $null
- 
- $aadapAppId =  Get-MgBetaApplication | where-object {$_.AppId -eq $item.AppId}
+ $itemAppId, $aadapAppId, $aadapAppConf, $aadapAppConf1 = $null, $null, $null, $null
+
+ $itemAppId = $item.AppId
+ $aadapAppId =  Get-MgBetaApplication -Filter "AppId eq '$itemAppId'"
  $aadapAppConf = Get-MgBetaApplication -ApplicationId $aadapAppId.Id -ErrorAction SilentlyContinue -select OnPremisesPublishing | select OnPremisesPublishing -expand OnPremisesPublishing 
  $aadapAppConf1 = Get-MgBetaApplication -ApplicationId $aadapAppId.Id -ErrorAction SilentlyContinue -select OnPremisesPublishing | select OnPremisesPublishing -expand OnPremisesPublishing `
   | select verifiedCustomDomainCertificatesMetadata -expand verifiedCustomDomainCertificatesMetadata 


### PR DESCRIPTION
This fixes the occasional "Get-MgBetaApplication : Cannot bind argument to parameter 'ApplicationId' because it is an empty string." on some apps.