### PR TITLE
Fix script Entra Domain Services Powershell Scope Synchronization.md

### DIFF
--- a/docs/identity/domain-services/powershell-scoped-synchronization.md
+++ b/docs/identity/domain-services/powershell-scoped-synchronization.md
@@ -94,7 +94,7 @@ foreach ($assignment in $currentAssignments)
 {
     Write-Output "Assignment-ObjectId: $($assignment.PrincipalId)"
 
-    if ($newGroupIds.Contains($assignment.PrincipalId) -eq $true)
+    if ($newGroupIds.Contains($assignment.PrincipalId) -eq $false)
     {
         Write-Output "This assignment is not needed anymore. Removing it! Assignment-ObjectId: $($assignment.PrincipalId)"
         Remove-MgServicePrincipalAppRoleAssignment -ServicePrincipalId $sp.Id -AppRoleAssignmentId $assignment.Id


### PR DESCRIPTION
The suggested script to configure the synchronized groups to Entra Domain Services contains a small error.

The role assignment should be removed if the Group/Principal Id does not exist in the `newGroupIds`