### PR TITLE
Workload identity federation: no need to get the Azure subscription ID

### DIFF
--- a/docs/workload-id/workload-identity-federation-create-trust.md
+++ b/docs/workload-id/workload-identity-federation-create-trust.md
@@ -73,8 +73,6 @@ Use the following values from your Microsoft Entra application registration for 
 
     ![Screenshot that demonstrates how to copy the application ID and tenant ID from Microsoft Entra admin center.](./media/workload-identity-federation-create-trust/copy-client-id.png)
 
-- `AZURE_SUBSCRIPTION_ID` your subscription ID. To get the subscription ID, open **Subscriptions** in [Azure portal](https://portal.azure.com) and find your subscription. Then, copy the **Subscription ID**.
-
 #### Entity type examples
 
 ##### Branch example


### PR DESCRIPTION
This Entra ID auth flow does not necessarily need an Azure subscription. For example, if the goal is to access Entra ID / MS Graph only, and not the Azure RM API, it's totally unnecessary. The JWT token obtained from the external identity provider, and then sent to Entra ID to get an Entra access token, does not need the subscription ID.

Related PR: https://github.com/Azure/login/pull/471