### PR TITLE
Corrected Old URL plus Noted Issue Described Below

### DIFF
--- a/docs/identity/hybrid/cloud-sync/tutorial-existing-forest.md
+++ b/docs/identity/hybrid/cloud-sync/tutorial-existing-forest.md
@@ -44,7 +44,7 @@ In this scenario, there's an existing forest synced using Microsoft Entra Connec
      | **8080** (optional) | Agents report their status every 10 minutes over port 8080, if port 443 is unavailable. This status is displayed on the portal. |
      
      If your firewall enforces rules according to the originating users, open these ports for traffic from Windows services that run as a network service.
-   - If your firewall or proxy allows you to specify safe suffixes, then add  connections to **\*.msappproxy.net** and **\*.servicebus.windows.net**. If not, allow access to the [Azure datacenter IP ranges](https://www.microsoft.com/download/details.aspx?id=41653), which are updated weekly.
+   - If your firewall or proxy allows you to specify safe suffixes, then add  connections to **\*.msappproxy.net** and **\*.servicebus.windows.net**. If not, allow access to the [Azure datacenter IP ranges](https://www.microsoft.com/en-us/download/details.aspx?id=56519), which are updated weekly.
    - Your agents need access to **login.windows.net** and **login.microsoftonline.com** for initial registration. Open your firewall for those URLs as well.
    - For certificate validation, unblock the following URLs: **mscrl.microsoft.com:80**, **crl.microsoft.com:80**, **ocsp.msocsp.com:80**, and **www\.microsoft.com:80**. Since these URLs are used for certificate validation with other Microsoft products, you may already have these URLs unblocked.
 


### PR DESCRIPTION
Please investigate as the tutorial section of this article is identical to https://learn.microsoft.com/en-us/entra/identity/hybrid/cloud-sync/tutorial-single-forest which appears just above it rather than describing intended integration steps outlined in the title / early portion of the article.