### PR TITLE
Fixed misencoded quote

### DIFF
--- a/docs/id-governance/governance-custom-alerts.md
+++ b/docs/id-governance/governance-custom-alerts.md
@@ -173,8 +173,8 @@ AuditLogs
 
 ```
 AADProvisioningLogs
-| where JobId == “<input JobId>”
-| where resultType == “Failure”
+| where JobId == "<input JobId>"
+| where resultType == "Failure"
 ```
 
 


### PR DESCRIPTION
The query for provisioning log failures wouldn't execute due to the quote string getting weird