### PR TITLE
Update optional-claims.md

### DIFF
--- a/docs/identity-platform/optional-claims.md
+++ b/docs/identity-platform/optional-claims.md
@@ -185,7 +185,7 @@ Complete the following steps to configure groups optional claims through the app
 
    Some applications require group information about the user in the role claim. To change the claim type from a group claim to a role claim, add `emit_as_roles` to `additionalProperties`.  The group values are emitted in the role claim.
 
-   If `emit_as_roles` is used, any application roles configured that the user is assigned aren't in the role claim.
+   If `emit_as_roles` is used, any application roles configured that the user (or a resource application) is assigned aren't in the role claim.
 
 The following examples show the manifest configuration for group claims:
 


### PR DESCRIPTION
a resource app can also be assigned to AppRole, so make this clear that even in an app only flow, and a resource app is assigned to an appRole, as long as emit_as_roles is configured the behavior also applies.  https://identitydivision.visualstudio.com/Engineering/_queries/edit/3001508/?triage=true  Feature 3001508: [DOC]APPX: emit_as_roles would cancel app roles from user's access token