### PR TITLE
Update how-to-configure-global-access-with-pim.md

### DIFF
--- a/docs/global-secure-access/how-to-configure-global-access-with-pim.md
+++ b/docs/global-secure-access/how-to-configure-global-access-with-pim.md
@@ -101,7 +101,7 @@ Even if a user and their device meet security requirements, attempting to access
 
 Next, we activate group membership using the Microsoft Entra admin center, and then attempt to connect with the new role activated.
 
-1. Sign in to [Microsoft Entra](https://entra.microsoft.com/) as at least a [Privileged Role Administrator](~/id-governance/privileged-identity-management/pim-configure.md).
+1. Sign in to [Microsoft Entra](https://entra.microsoft.com/)
 1. Browse to  **Identity Governance**  > **Privileged Identity Management**. 
 1. Select **My roles** > **Groups** to see all eligible assignments.
 


### PR DESCRIPTION
Removed the requirement to be "Privileged Role Admin" to activate the role needed. A normal user which would need access to the role, doesn't need access to the  "Privileged Role Admin" role.