### PR TITLE
Update how-to-configure-sso-with-kcd.md

### DIFF
--- a/docs/identity/app-proxy/how-to-configure-sso-with-kcd.md
+++ b/docs/identity/app-proxy/how-to-configure-sso-with-kcd.md
@@ -40,7 +40,7 @@ Before you get started with single sign-on for IWA applications, make sure your 
 * Your apps, like SharePoint Web apps, are set to use integrated Windows authentication. For more information, see [Enable Support for Kerberos Authentication](/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/dd759186(v=ws.11)), or for SharePoint see [Plan for Kerberos authentication in SharePoint 2013](/SharePoint/security-for-sharepoint-server/kerberos-authentication-planning).
 * All your apps have [Service Principal Names](/windows/win32/ad/service-principal-names).
 * The server running the Connector and the server running the app are domain joined and part of the same domain or trusting domains. For more information on domain join, see [Join a Computer to a Domain](/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/dd807102(v=ws.11)).
-* The server running the Connector has access to read the TokenGroupsGlobalAndUniversal attribute for users. This default setting might have been impacted by security hardening the environment.
+* The server running the Connector has access to read the TokenGroupsGlobalAndUniversal attribute for users. This default setting might have been impacted by security hardening the environment. Adding the Connector servers to the "Windows Authorization Access Group" will normally do this.
 
 ### Configure Active Directory
 The Active Directory configuration varies, depending on whether your private network connector and the application server are in the same domain or not.


### PR DESCRIPTION
There is not really a how-to to give the Connector Servers access to the TokenGroupsGlobalAndUniversal attribute. We saw that adding them to the Windows Authorization Access Group did the trick instantly. It's good to add this here.