### PR TITLE
Update documentation for custom extensions

### DIFF
--- a/docs/identity-platform/custom-claims-provider-reference.md
+++ b/docs/identity-platform/custom-claims-provider-reference.md
@@ -79,7 +79,7 @@ POST https://your-api.com/endpoint
                 "displayName": "My Test application"
             },
             "user": {
-                "companyName": "Casey Jensen"
+                "companyName": "Casey Jensen",
                 "createdDateTime": "2016-03-01T15:23:40Z",
                 "displayName": "Casey Jensen",
                 "givenName": "Casey",


### PR DESCRIPTION
Updating the example in the Custom Claims provider in Microsoft Entra documentation. It wasn't a valid JSON document.