### PR TITLE
Fix broken managed identity links

### DIFF
--- a/docs/identity/managed-identities-azure-resources/index.yml
+++ b/docs/identity/managed-identities-azure-resources/index.yml
@@ -63,4 +63,4 @@ landingContent:
           - text: CLI
             url: how-to-assign-access-azure-resource?pivots=identity-mi-access-cli
           - text: PowerShell
-            url: hhow-to-assign-access-azure-resource?pivots=identity-mi-access-powershell
+            url: hhow-to-assign-access-azure-resource?pivots=identity-mi-access-powershell.md

--- a/docs/identity/managed-identities-azure-resources/index.yml
+++ b/docs/identity/managed-identities-azure-resources/index.yml
@@ -59,8 +59,8 @@ landingContent:
       - linkListType: how-to-guide
         links:
           - text: Portal
-            url: howto-assign-access-portal.md
+            url: how-to-configure-managed-identities-scale-sets?pivots=identity-mi-methods-azp
           - text: CLI
-            url: howto-assign-access-cli.md
+            url: how-to-assign-access-azure-resource?pivots=identity-mi-access-cli
           - text: PowerShell
-            url: howto-assign-access-powershell.md
+            url: hhow-to-assign-access-azure-resource?pivots=identity-mi-access-powershell

--- a/docs/identity/managed-identities-azure-resources/index.yml
+++ b/docs/identity/managed-identities-azure-resources/index.yml
@@ -59,7 +59,7 @@ landingContent:
       - linkListType: how-to-guide
         links:
           - text: Portal
-            url: how-to-configure-managed-identities-scale-sets?pivots=identity-mi-methods-azp
+            url: how-to-configure-managed-identities-scale-sets?pivots=identity-mi-methods-azp.md
           - text: CLI
             url: how-to-assign-access-azure-resource?pivots=identity-mi-access-cli.md
           - text: PowerShell

--- a/docs/identity/managed-identities-azure-resources/index.yml
+++ b/docs/identity/managed-identities-azure-resources/index.yml
@@ -61,6 +61,6 @@ landingContent:
           - text: Portal
             url: how-to-configure-managed-identities-scale-sets?pivots=identity-mi-methods-azp
           - text: CLI
-            url: how-to-assign-access-azure-resource?pivots=identity-mi-access-cli
+            url: how-to-assign-access-azure-resource?pivots=identity-mi-access-cli.md
           - text: PowerShell
             url: hhow-to-assign-access-azure-resource?pivots=identity-mi-access-powershell.md

--- a/docs/identity/managed-identities-azure-resources/index.yml
+++ b/docs/identity/managed-identities-azure-resources/index.yml
@@ -59,8 +59,8 @@ landingContent:
       - linkListType: how-to-guide
         links:
           - text: Portal
-            url: how-to-configure-managed-identities-scale-sets?pivots=identity-mi-methods-azp.md
+            url: how-to-configure-managed-identities-scale-sets.md?pivots=identity-mi-methods-azp
           - text: CLI
-            url: how-to-assign-access-azure-resource?pivots=identity-mi-access-cli.md
+            url: how-to-assign-access-azure-resource.md?pivots=identity-mi-access-cli
           - text: PowerShell
-            url: hhow-to-assign-access-azure-resource?pivots=identity-mi-access-powershell.md
+            url: hhow-to-assign-access-azure-resource.md?pivots=identity-mi-access-powershell

--- a/docs/identity/managed-identities-azure-resources/index.yml
+++ b/docs/identity/managed-identities-azure-resources/index.yml
@@ -63,4 +63,4 @@ landingContent:
           - text: CLI
             url: how-to-assign-access-azure-resource.md?pivots=identity-mi-access-cli
           - text: PowerShell
-            url: hhow-to-assign-access-azure-resource.md?pivots=identity-mi-access-powershell
+            url: how-to-assign-access-azure-resource.md?pivots=identity-mi-access-powershell


### PR DESCRIPTION
Reroutes links to how to guides for managed identity resource assignment to the new correct location