### PR TITLE
Update workbook-mfa-gaps.md

### DIFF
--- a/docs/identity/monitoring-health/workbook-mfa-gaps.md
+++ b/docs/identity/monitoring-health/workbook-mfa-gaps.md
@@ -41,7 +41,7 @@ The **MFA gaps** workbook is currently not available as a template, but you can 
 
 1. Navigate to the Microsoft Entra workbooks GitHub repository
     - **Direct link to the Multifactor Authentication Gaps JSON file**: https://github.com/microsoft/Application-Insights-Workbooks/blob/master/Workbooks/Azure%20Active%20Directory/MultiFactorAuthenticationGaps/MultiFactorAuthenticationGaps.workbook
-    - Select the link provided in the JSON editor, select the **Application-Insights-Workbooks** breadcrumb from the top of the page, select the **Workbooks** folder, select the **Microsoft Entra ID** folder, select the **MultiFactorAuthenticationGaps** folder, and open the **.workbook** file.
+    - Select the link provided in the JSON editor, select the **Application-Insights-Workbooks** breadcrumb from the top of the page, select the **Workbooks** folder, select the **Azure Active Directory** folder, select the **MultiFactorAuthenticationGaps** folder, and open the **.workbook** file.
     ![Screenshot of the GitHub repository with the breadcrumbs and copy file button highlighted.](./media/workbook-mfa-gaps/github-repository.png)
 1. Copy the entire JSON file from the GitHub repository.
 1. Return Advanced Editor window on the Azure portal and paste the JSON file over the exiting text.


### PR DESCRIPTION
The workbook is still located in a folder called "Azure Active Directory" while the documentation says "Microsoft Entra ID." This is reflected in the screenshots as well. There is no folder currently called "Microsoft Entra ID"