### PR TITLE
Update sample-single-page-app-vanillajs-sign-in.md

### DIFF
--- a/docs/external-id/customers/sample-single-page-app-vanillajs-sign-in.md
+++ b/docs/external-id/customers/sample-single-page-app-vanillajs-sign-in.md
@@ -72,7 +72,8 @@ To obtain the sample application, you can either clone it from GitHub or downloa
 
      * `Enter_the_Application_Id_Here` and replace it with the Application (client) ID of the app you registered earlier.
      * `Enter_the_Tenant_Subdomain_Here` and replace it with the Directory (tenant) subdomain. For example, if your tenant primary domain is `contoso.onmicrosoft.com`, use `contoso`. If you don't have your tenant name, learn how to [read your tenant details](how-to-create-customer-tenant-portal.md#get-the-customer-tenant-details).
-
+     * `redirectUri: 'http://localhost:3000/redirect'`, Remove this line to redirect to the default value `http://localhost:3000/`. Otherwise you have to configure the redirect `http://localhost:3000/redirect` in the chapter before.
+`
 1. Save the file.
 
 ## Run your project and sign in


### PR DESCRIPTION
The part of the documentation is misleading. In the previous chapter you are told to create the path localhost:3000 as a redirect in the app registration. However, the cloned repository points to the path localhost:3000/redirect by default.

This PR adds an information that if you want to use the configured url (localhost:3000), you also have to delete the property in the repository so that the default value is used.

This information was previously missing in the list of adjustments to be made.