### PR TITLE
Update how-to-connect-pta-disable-do-not-configure.md

### DIFF
--- a/docs/identity/hybrid/connect/how-to-connect-pta-disable-do-not-configure.md
+++ b/docs/identity/hybrid/connect/how-to-connect-pta-disable-do-not-configure.md
@@ -56,6 +56,7 @@ In a PowerShell session, run the following cmdlets:
 1. PS C:\Program Files\Microsoft Azure AD Connect Authentication Agent> `Import-Module .\Modules\PassthroughAuthPSModule`
 2. `Get-PassthroughAuthenticationEnablementStatus`
 3. `Disable-PassthroughAuthentication`
+      a. A warning prompt will appear when the disable-passthroughauthentication command is run - "WARNING: We recommend that you enabled Password Hash Synchronization before you disable Pas-Trough Authentication. And use a cloud-only Global Administrator account to run this cmdlet. These steps ensure that you are not locked out of your tenant"  Please enter to continue...:
 
 ## Next steps
 


### PR DESCRIPTION
add the warning prompt that will appear in powershell. This way customers are informed on what to expected

a. A warning prompt will appear when the disable-passthroughauthentication command is run - "WARNING: We recommend that you enabled Password Hash Synchronization before you disable Pas-Trough Authentication. And use a cloud-only Global Administrator account to run this cmdlet. These steps ensure that you are not locked out of your tenant"  Please enter to continue...: