### PR TITLE
Update default AllowRD rule

### DIFF
--- a/docs/identity/domain-services/alert-nsg.md
+++ b/docs/identity/domain-services/alert-nsg.md
@@ -34,13 +34,13 @@ The following default inbound and outbound security rules are applied to the net
 | Priority | Name | Port | Protocol | Source | Destination | Action |
 |----------|------|------|----------|--------|-------------|--------|
 | 301      | AllowPSRemoting | 5986| TCP | AzureActiveDirectoryDomainServices | Any | Allow |
-| 201      | AllowRD | 3389 | TCP | CorpNetSaw | Any | Deny<sup>1</sup> |
+| 201      | AllowRD | 3389 | TCP | CorpNetSaw | Any | Allow<sup>1</sup> |
 | 65000    | AllVnetInBound | Any | Any | VirtualNetwork | VirtualNetwork | Allow |
 | 65001    | AllowAzureLoadBalancerInBound | Any | Any | AzureLoadBalancer | Any | Allow |
 | 65500    | DenyAllInBound | Any | Any | Any | Any | Deny |
 
 
-<sup>1</sup>Optional for debugging. Allow when required for advanced troubleshooting.
+<sup>1</sup>Optional for debugging but change the default to deny when not needed. Allow the rule when required for advanced troubleshooting.
 
 > [!NOTE]
 > You may also have an additional rule that allows inbound traffic if you [configure secure LDAP][configure-ldaps]. This additional rule is required for the correct LDAPS communication.


### PR DESCRIPTION
Default Inbound security rule has AllowRD on enabled. Admin's should deny the traffic when RDP isn't needed and should only allow it when doing advanced diagnostic work.

The documents now give the expression that the traffic (rule) is denied by default but that's isn't true.
