### PR TITLE
Update howto-mfa-nps-extension.md

### DIFF
--- a/docs/identity/authentication/howto-mfa-nps-extension.md
+++ b/docs/identity/authentication/howto-mfa-nps-extension.md
@@ -318,7 +318,8 @@ This section includes design considerations and suggestions for successful NPS e
 
 ### Configuration limitations
 
-- The NPS extension for Microsoft Entra multifactor authentication doesn't include tools to migrate users and settings from MFA Server to the cloud. For this reason, we suggest using the extension for new deployments, rather than existing deployment. If you use the extension on an existing deployment, your users have to perform proof-up again to populate their MFA details in the cloud.  
+- The NPS extension for Microsoft Entra multifactor authentication doesn't include tools to migrate users and settings from MFA Server to the cloud. For this reason, we suggest using the extension for new deployments, rather than existing deployment. If you use the extension on an existing deployment, your users have to perform proof-up again to populate their MFA details in the cloud.
+- The NPS extension doesn't support custom phone calls configured on Phone call settings. The default phone call language will be used (EN-US). 
 - The NPS extension uses the UPN from the on-premises AD DS environment to identify the user on Microsoft Entra multifactor authentication for performing the Secondary Auth. The extension can be configured to use a different identifier like alternate login ID or custom AD DS field other than UPN. For more information, see the article, [Advanced configuration options for the NPS extension for multifactor authentication](howto-mfa-nps-extension-advanced.md).
 - Not all encryption protocols support all verification methods.
    - **PAP** supports phone call, one-way text message, mobile app notification, and mobile app verification code


### PR DESCRIPTION
As a Support Engineer at MSFT, I'm supporting a customer on an new NPS Extension deployment where customer has custom phone calls configured on Entra that are only working when signing-in on Entra where the browser default language is checked and the custom call in Hungarian is being triggered.  The same doesn't happen when phone calls are received to complete MFA, triggered by the NPS Extension.

An IcM (542785256) was created with not confirmation yet, but in an internal discussion with MFA Server PG, it was confirmed that: "When signing directly into Entra ID (ESTS), we use the browser language to determine what language to use during the voice call.  When NPS Extension is used, there is no language context for the user so it defaults to English."