### PR TITLE
By design for user consent when user assignment required.md

### DIFF
--- a/docs/identity/enterprise-apps/configure-user-consent.md
+++ b/docs/identity/enterprise-apps/configure-user-consent.md
@@ -173,6 +173,9 @@ PATCH https://graph.microsoft.com/v1.0/policies/authorizationPolicy
 > [!TIP]
 > To allow users to request an administrator's review and approval of an application that the user isn't allowed to consent to, [enable the admin consent workflow](configure-admin-consent-workflow.md). For example, you might do this when user consent has been disabled or when an application is requesting permissions that the user isn't allowed to grant.
 
+> [!NOTE]
+> When an application requires assignment, user consent for that application isn't allowed. This is true even if users consent for that app would have otherwise been allowed. Be sure to [grant tenant-wide admin consent](~/identity/enterprise-apps/grant-admin-consent.md) to apps that require assignment.
+
 ## Next steps
 
 - [Manage app consent policies](manage-app-consent-policies.md)


### PR DESCRIPTION
There is a design that user consent doesn't work when user assignment is required. It is documented on this public doc. https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/what-is-access-management#requiring-user-assignment-for-an-app

The reason is explained by PG on this Github.
https://github.com/MicrosoftDocs/azure-docs/issues/59982#issuecomment-863975170

It will be great to mention on this doc too so that customers can be aware of the design when they read this document.