### PR TITLE
Update how-to-enable-passkey-fido2.md

### DIFF
--- a/docs/identity/authentication/how-to-enable-passkey-fido2.md
+++ b/docs/identity/authentication/how-to-enable-passkey-fido2.md
@@ -178,7 +178,7 @@ Registration of FIDO2 credentials isn't supported for B2B collaboration users in
 
 ### Security key provisioning
 
-Administrator provisioning and deprovisioning of security keys isn't available.
+Administrator provisioning of security keys is in public preview. See [Microsoft Graph and custom clients to provision FIDO2 security keys on behalf of users](https://aka.ms/passkeyprovision).
 
 ### UPN changes
 


### PR DESCRIPTION
Updated the bottom section on Security Key provisioning, that now admin provisioning is in public preview. 

Request for clarification - if my tenant already has security keys, and I want to ALSO add authenticator app passkeys, if I turn on "enforce key restrictions," will my users be blocked from using their existing keys if I don't list out ALL the AAGUIDS being used in the tenant? 

(In other words, the content around "Enforce key restrictions" plus "allow" vs. "block" is really confusing and could use an example. (And I'm the FORMER PM for this :D)