### PR TITLE
Update howto-authentication-methods-activity.md

### DIFF
--- a/docs/identity/authentication/howto-authentication-methods-activity.md
+++ b/docs/identity/authentication/howto-authentication-methods-activity.md
@@ -136,7 +136,8 @@ The registration details report shows the following information for each user:
 ## Limitations
 
 - The data in the report is not updated in real-time and may reflect a latency of up to a few hours.
-- The **PhoneAppNotification** or **PhoneAppOTP** methods that a user might have configured are not displayed in the dashboard on **Microsoft Entra authentication methods - Policies**. 
+- The **PhoneAppNotification** or **PhoneAppOTP** methods that a user might have configured are not displayed in the dashboard on **Microsoft Entra authentication methods - Policies**.
+- Bulk operations in the Microsoft Entra admin portal could time out and fail on very large tenants. This limitation is a known issue due to scaling limitations. The Microsoft engineering team is working on a new service that will eventually address this limitation.
 
 ## Next steps
 

--- a/docs/identity/authentication/howto-authentication-methods-activity.md
+++ b/docs/identity/authentication/howto-authentication-methods-activity.md
@@ -137,7 +137,7 @@ The registration details report shows the following information for each user:
 
 - The data in the report is not updated in real-time and may reflect a latency of up to a few hours.
 - The **PhoneAppNotification** or **PhoneAppOTP** methods that a user might have configured are not displayed in the dashboard on **Microsoft Entra authentication methods - Policies**.
-- Bulk operations in the Microsoft Entra admin portal could time out and fail on very large tenants. This limitation is a known issue due to scaling limitations. For more information, please check [Bulk operations](https://learn.microsoft.com/entra/fundamentals/bulk-operations-service-limitations?WT.mc_id=Portal-Microsoft_AAD_IAM).
+- Bulk operations in the Microsoft Entra admin portal could time out and fail on very large tenants. This limitation is a known issue due to scaling limitations. For more information, see [Bulk operations](https://learn.microsoft.com/entra/fundamentals/bulk-operations-service-limitations?WT.mc_id=Portal-Microsoft_AAD_IAM).
 
 
 ## Next steps

--- a/docs/identity/authentication/howto-authentication-methods-activity.md
+++ b/docs/identity/authentication/howto-authentication-methods-activity.md
@@ -137,7 +137,7 @@ The registration details report shows the following information for each user:
 
 - The data in the report is not updated in real-time and may reflect a latency of up to a few hours.
 - The **PhoneAppNotification** or **PhoneAppOTP** methods that a user might have configured are not displayed in the dashboard on **Microsoft Entra authentication methods - Policies**.
-- Bulk operations in the Microsoft Entra admin portal could time out and fail on very large tenants. This limitation is a known issue due to scaling limitations. For more information, please check [Bulk operations]([https://www.microsoft.com/security/business/identity-access-management/azure-ad-pricing](https://learn.microsoft.com/en-us/entra/fundamentals/bulk-operations-service-limitations?WT.mc_id=Portal-Microsoft_AAD_IAM).
+- Bulk operations in the Microsoft Entra admin portal could time out and fail on very large tenants. This limitation is a known issue due to scaling limitations. For more information, please check [Bulk operations](https://learn.microsoft.com/en-us/entra/fundamentals/bulk-operations-service-limitations?WT.mc_id=Portal-Microsoft_AAD_IAM).
 
 
 ## Next steps

--- a/docs/identity/authentication/howto-authentication-methods-activity.md
+++ b/docs/identity/authentication/howto-authentication-methods-activity.md
@@ -137,7 +137,7 @@ The registration details report shows the following information for each user:
 
 - The data in the report is not updated in real-time and may reflect a latency of up to a few hours.
 - The **PhoneAppNotification** or **PhoneAppOTP** methods that a user might have configured are not displayed in the dashboard on **Microsoft Entra authentication methods - Policies**.
-- Bulk operations in the Microsoft Entra admin portal could time out and fail on very large tenants. This limitation is a known issue due to scaling limitations. For more information, see [Bulk operations](https://learn.microsoft.com/entra/fundamentals/bulk-operations-service-limitations?WT.mc_id=Portal-Microsoft_AAD_IAM).
+- Bulk operations in the Microsoft Entra admin portal could time out and fail on very large tenants. This limitation is a known issue due to scaling limitations. For more information, see [Bulk operations](/entra/fundamentals/bulk-operations-service-limitations?WT.mc_id=Portal-Microsoft_AAD_IAM).
 
 
 ## Next steps

--- a/docs/identity/authentication/howto-authentication-methods-activity.md
+++ b/docs/identity/authentication/howto-authentication-methods-activity.md
@@ -137,7 +137,7 @@ The registration details report shows the following information for each user:
 
 - The data in the report is not updated in real-time and may reflect a latency of up to a few hours.
 - The **PhoneAppNotification** or **PhoneAppOTP** methods that a user might have configured are not displayed in the dashboard on **Microsoft Entra authentication methods - Policies**.
-- Bulk operations in the Microsoft Entra admin portal could time out and fail on very large tenants. This limitation is a known issue due to scaling limitations. The Microsoft engineering team is working on a new service that will eventually address this limitation.
+- Bulk operations in the Microsoft Entra admin portal could time out and fail on very large tenants. This limitation is a known issue due to scaling limitations. For more information, please check [Bulk operations]([https://www.microsoft.com/security/business/identity-access-management/azure-ad-pricing](https://learn.microsoft.com/en-us/entra/fundamentals/bulk-operations-service-limitations?WT.mc_id=Portal-Microsoft_AAD_IAM))
 
 ## Next steps
 

--- a/docs/identity/authentication/howto-authentication-methods-activity.md
+++ b/docs/identity/authentication/howto-authentication-methods-activity.md
@@ -137,7 +137,7 @@ The registration details report shows the following information for each user:
 
 - The data in the report is not updated in real-time and may reflect a latency of up to a few hours.
 - The **PhoneAppNotification** or **PhoneAppOTP** methods that a user might have configured are not displayed in the dashboard on **Microsoft Entra authentication methods - Policies**.
-- Bulk operations in the Microsoft Entra admin portal could time out and fail on very large tenants. This limitation is a known issue due to scaling limitations. For more information, please check [Bulk operations](https://learn.microsoft.com/en-us/entra/fundamentals/bulk-operations-service-limitations?WT.mc_id=Portal-Microsoft_AAD_IAM).
+- Bulk operations in the Microsoft Entra admin portal could time out and fail on very large tenants. This limitation is a known issue due to scaling limitations. For more information, please check [Bulk operations](https://learn.microsoft.com/entra/fundamentals/bulk-operations-service-limitations?WT.mc_id=Portal-Microsoft_AAD_IAM).
 
 
 ## Next steps

--- a/docs/identity/authentication/howto-authentication-methods-activity.md
+++ b/docs/identity/authentication/howto-authentication-methods-activity.md
@@ -137,7 +137,8 @@ The registration details report shows the following information for each user:
 
 - The data in the report is not updated in real-time and may reflect a latency of up to a few hours.
 - The **PhoneAppNotification** or **PhoneAppOTP** methods that a user might have configured are not displayed in the dashboard on **Microsoft Entra authentication methods - Policies**.
-- Bulk operations in the Microsoft Entra admin portal could time out and fail on very large tenants. This limitation is a known issue due to scaling limitations. For more information, please check [Bulk operations]([https://www.microsoft.com/security/business/identity-access-management/azure-ad-pricing](https://learn.microsoft.com/en-us/entra/fundamentals/bulk-operations-service-limitations?WT.mc_id=Portal-Microsoft_AAD_IAM))
+- Bulk operations in the Microsoft Entra admin portal could time out and fail on very large tenants. This limitation is a known issue due to scaling limitations. For more information, please check [Bulk operations]([https://www.microsoft.com/security/business/identity-access-management/azure-ad-pricing](https://learn.microsoft.com/en-us/entra/fundamentals/bulk-operations-service-limitations?WT.mc_id=Portal-Microsoft_AAD_IAM).
+
 
 ## Next steps
 


### PR DESCRIPTION
I'm working on a case where customer is having issues to download a large report for around 4k users. He is being prompted for a "Bulk operation failed". When same customer applies some filters and have less users on the report, they are able to download it without any issues.
No issues when downloading the report with filters applied for few users.

On the same User registration details report UI, on the right side pane when we clicked on the "Download" button, we can see a warning banner stating: "Please be aware of the bulk operations service limitations before using this feature. Operations can only run for up to 1 hour and has known issues in large tenants".

Considering this warning and known issue, I believe somehow we need to have this documented as part of the Limitations section on this doc.

The proposed addition was retrieved from the following doc, which is available from the same UI: https://learn.microsoft.com/en-us/entra/fundamentals/bulk-operations-service-limitations?WT.mc_id=Portal-Microsoft_AAD_IAM 