### PR TITLE
fix wrong requirements to activate Azure Role via PIM

### DIFF
--- a/docs/id-governance/privileged-identity-management/pim-resource-roles-activate-your-roles.yml
+++ b/docs/id-governance/privileged-identity-management/pim-resource-roles-activate-your-roles.yml
@@ -42,7 +42,7 @@ procedureSection:
 
     steps:
       - |
-        Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com) as at least a [Privileged Role Administrator](~/identity/role-based-access-control/permissions-reference.md#privileged-role-administrator).
+        Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com).
       - |
         Browse to **Identity governance** > **Privileged Identity Management** > **My roles**.
 


### PR DESCRIPTION
It is not required to have an Admin Role to activate a role for an Azure resource.