### PR TITLE
Update GitHub EMU GHE.com tutorial to point to the correct app

### DIFF
--- a/docs/identity/saas-apps/github-enterprise-managed-user-ghe-com-tutorial.md
+++ b/docs/identity/saas-apps/github-enterprise-managed-user-ghe-com-tutorial.md
@@ -1,6 +1,6 @@
 ---
-title: Microsoft Entra SSO integration with GitHub Enterprise Managed User - ghe.com
-description: Learn how to configure single sign-on between Microsoft Entra ID and GitHub Enterprise Managed User - ghe.com.
+title: Microsoft Entra SSO integration with GitHub Enterprise Managed User - GHE.com
+description: Learn how to configure single sign-on between Microsoft Entra ID and GitHub Enterprise Managed User.
 
 author: jeevansd
 manager: CelesteDG
@@ -11,52 +11,52 @@ ms.topic: how-to
 ms.date: 06/28/2024
 ms.author: jeedes
 
-# Customer intent: As an IT administrator, I want to learn how to configure single sign-on between Microsoft Entra ID and GitHub Enterprise Managed User - ghe.com so that I can control who has access to GitHub Enterprise Managed User - ghe.com, enable automatic sign-in with Microsoft Entra accounts, and manage my accounts in one central location.
+# Customer intent: As an IT administrator, I want to learn how to configure single sign-on between Microsoft Entra ID and GitHub Enterprise Managed User so that I can control who has access to GitHub Enterprise Managed User, enable automatic sign-in with Microsoft Entra accounts, and manage my accounts in one central location.
 ---
 
-# Microsoft Entra SSO integration with GitHub Enterprise Managed User - ghe.com
+# Microsoft Entra SSO integration with GitHub Enterprise Managed User
 
-In this tutorial, you'll learn how to integrate GitHub Enterprise Managed User - ghe.com with Microsoft Entra ID. When you integrate GitHub Enterprise Managed User - ghe.com with Microsoft Entra ID, you can:
+In this tutorial, you'll learn how to integrate GitHub Enterprise Managed User with Microsoft Entra ID. When you integrate GitHub Enterprise Managed User with Microsoft Entra ID, you can:
 
-* Control in Microsoft Entra ID who has access to GitHub Enterprise Managed User - ghe.com.
-* Enable your users to be automatically signed-in to GitHub Enterprise Managed User - ghe.com with their Microsoft Entra accounts.
+* Control in Microsoft Entra ID who has access to GitHub Enterprise Managed User
+* Enable your users to be automatically signed-in to GitHub Enterprise Managed User with their Microsoft Entra accounts.
 * Manage your accounts in one central location.
 
 ## Prerequisites
 
-To integrate Microsoft Entra ID with GitHub Enterprise Managed User - ghe.com, you need:
+To integrate Microsoft Entra ID with GitHub Enterprise Managed User, you need:
 
 * A Microsoft Entra subscription. If you don't have a subscription, you can get a [free account](https://azure.microsoft.com/free/).
-* GitHub Enterprise Managed User - ghe.com single sign-on (SSO) enabled subscription.
+* GitHub Enterprise Managed User single sign-on (SSO) enabled subscription.
 
 ## Scenario description
 
 In this tutorial, you configure and test Microsoft Entra SSO in a test environment.
 
-* GitHub Enterprise Managed User - ghe.com supports both **SP and IDP** initiated SSO.
+* GitHub Enterprise Managed User supports both **SP and IDP** initiated SSO.
 
-## Add GitHub Enterprise Managed User - ghe.com from the gallery
+## Adding GitHub Enterprise Managed User from the gallery
 
-To configure the integration of GitHub Enterprise Managed User - ghe.com into Microsoft Entra ID, you need to add GitHub Enterprise Managed User - ghe.com from the gallery to your list of managed SaaS apps.
+To configure the integration of GitHub Enterprise Managed User into Microsoft Entra ID, you need to add GitHub Enterprise Managed User from the gallery to your list of managed SaaS apps.
 
 1. Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com) as at least a [Cloud Application Administrator](~/identity/role-based-access-control/permissions-reference.md#cloud-application-administrator).
 1. Browse to **Identity** > **Applications** > **Enterprise applications** > **New application**.
-1. In the **Add from the gallery** section, type **GitHub Enterprise Managed User - ghe.com** in the search box.
-1. Select **GitHub Enterprise Managed User - ghe.com** from results panel and then add the app. Wait a few seconds while the app is added to your tenant.
+1. Type **GitHub Enterprise Managed User** in the search box.
+1. Select **GitHub Enterprise Managed User** from results panel and then click on the **Create** button. Wait a few seconds while the app is added to your tenant.
 
-Alternatively, you can also use the [Enterprise App Configuration Wizard](https://portal.office.com/AdminPortal/home?Q=Docs#/azureadappintegration). In this wizard, you can add an application to your tenant, add users/groups to the app, assign roles, and walk through the SSO configuration as well. [Learn more about Microsoft 365 wizards.](/microsoft-365/admin/misc/azure-ad-setup-guides)
+ Alternatively, you can also use the [Enterprise App Configuration Wizard](https://portal.office.com/AdminPortal/home?Q=Docs#/azureadappintegration). In this wizard, you can add an application to your tenant, add users/groups to the app, assign roles, as well as walk through the SSO configuration as well. [Learn more about Microsoft 365 wizards.](/microsoft-365/admin/misc/azure-ad-setup-guides)
 
-## Configure and test Microsoft Entra SSO for GitHub Enterprise Managed User - ghe.com
+## Configure and test Microsoft Entra SSO for GitHub Enterprise Managed User
 
-Configure and test Microsoft Entra SSO with GitHub Enterprise Managed User - ghe.com using a test user called **B.Simon**. For SSO to work, you need to establish a link relationship between a Microsoft Entra user and the related user in GitHub Enterprise Managed User - ghe.com.
+Configure and test Microsoft Entra SSO with GitHub Enterprise Managed User using a test user called **B.Simon**. For SSO to work, you need to establish a link relationship between a Microsoft Entra user and the related user in GitHub Enterprise Managed User.
 
-To configure and test Microsoft Entra SSO with GitHub Enterprise Managed User - ghe.com, perform the following steps:
+To configure and test Microsoft Entra SSO with GitHub Enterprise Managed User, perform the following steps:
 
 1. **[Configure Microsoft Entra SSO](#configure-microsoft-entra-sso)** - to enable your users to use this feature.
     1. **[Create a Microsoft Entra ID test user](#create-a-microsoft-entra-id-test-user)** - to test Microsoft Entra single sign-on with B.Simon.
     1. **[Assign the Microsoft Entra ID test user](#assign-the-microsoft-entra-id-test-user)** - to enable B.Simon to use Microsoft Entra single sign-on.
-1. **[Configure GitHub Enterprise Managed User - ghe.com SSO](#configure-github-enterprise-managed-user---ghecom-sso)** - to configure the single sign-on settings on application side.
-    1. **[Create GitHub Enterprise Managed User - ghe.com test user](#create-github-enterprise-managed-user---ghecom-test-user)** - to have a counterpart of B.Simon in GitHub Enterprise Managed User - ghe.com that is linked to the Microsoft Entra ID representation of user.
+1. **[Configure GitHub Enterprise Managed User SSO](#configure-github-enterprise-managed-user---ghecom-sso)** - to configure the single sign-on settings on application side.
+    1. **[Create GitHub Enterprise Managed User test user](#create-github-enterprise-managed-user---ghecom-test-user)** - to have a counterpart of B.Simon in GitHub Enterprise Managed User that is linked to the Microsoft Entra ID representation of user.
 1. **[Test SSO](#test-sso)** - to verify whether the configuration works.
 
 ## Configure Microsoft Entra SSO
@@ -64,7 +64,7 @@ To configure and test Microsoft Entra SSO with GitHub Enterprise Managed User - 
 Follow these steps to enable Microsoft Entra SSO in the Microsoft Entra admin center.
 
 1. Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com) as at least a [Cloud Application Administrator](~/identity/role-based-access-control/permissions-reference.md#cloud-application-administrator).
-1. Browse to **Identity** > **Applications** > **Enterprise applications** > **GitHub Enterprise Managed User - ghe.com** > **Single sign-on**.
+1. Browse to **Identity** > **Applications** > **Enterprise applications** > **GitHub Enterprise Managed User** > **Single sign-on**.
 1. On the **Select a single sign-on method** page, select **SAML**.
 1. On the **Set up single sign-on with SAML** page, click the pencil icon for **Basic SAML Configuration** to edit the settings.
 
@@ -84,13 +84,13 @@ Follow these steps to enable Microsoft Entra SSO in the Microsoft Entra admin ce
     `https://<ENTERPRISE>.ghe.com/login`
 
 	> [!NOTE]
-	> These values are not real. Update these values with the actual Identifier, Reply URL and Sign on URL. Contact [GitHub Enterprise Managed User - ghe.com support team](https://support.github.com/early-access/data-residency) to get these values. You can also refer to the patterns shown in the **Basic SAML Configuration** section in the Microsoft Entra admin center.
+	> These values are not real. Update these values with the actual Identifier, Reply URL and Sign on URL. Contact [GitHub Enterprise Managed User support team](https://support.github.com/early-access/data-residency) to get these values. You can also refer to the patterns shown in the **Basic SAML Configuration** section in the Microsoft Entra admin center.
 
 1. On the **Set up single sign-on with SAML** page, in the **SAML Signing Certificate** section, find **Federation Metadata XML** and select **Download** to download the certificate and save it on your computer.
 
 	![Screenshot shows the Certificate download link.](common/metadataxml.png "Certificate")
 
-1. On the **Set up GitHub Enterprise Managed User - ghe.com** section, copy the appropriate URL(s) based on your requirement.
+1. On the **Set up GitHub Enterprise Managed User** section, copy the appropriate URL(s) based on your requirement.
 
 	![Screenshot shows to copy configuration URLs.](common/copy-configuration-urls.png "Metadata")
 
@@ -110,23 +110,23 @@ In this section, you'll create a test user in the Microsoft Entra admin center c
 
 ### Assign the Microsoft Entra ID test user
 
-In this section, you'll enable B.Simon to use Microsoft Entra single sign-on by granting access to GitHub Enterprise Managed User - ghe.com.
+In this section, you'll enable B.Simon to use Microsoft Entra single sign-on by granting access to GitHub Enterprise Managed User.
 
 1. Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com) as at least a [Cloud Application Administrator](~/identity/role-based-access-control/permissions-reference.md#cloud-application-administrator).
-1. Browse to **Identity** > **Applications** > **Enterprise applications** > **GitHub Enterprise Managed User - ghe.com**.
+1. Browse to **Identity** > **Applications** > **Enterprise applications** > **GitHub Enterprise Managed User**.
 1. In the app's overview page, select **Users and groups**.
 1. Select **Add user/group**, then select **Users and groups** in the **Add Assignment** dialog.
    1. In the **Users and groups** dialog, select **B.Simon** from the Users list, then click the **Select** button at the bottom of the screen.
    1. If you are expecting a role to be assigned to the users, you can select it from the **Select a role** dropdown. If no role has been set up for this app, you see "Default Access" role selected.
    1. In the **Add Assignment** dialog, click the **Assign** button.
 
-## Configure GitHub Enterprise Managed User - ghe.com SSO
+## Configure GitHub Enterprise Managed User SSO
 
-To configure single sign-on on **GitHub Enterprise Managed User - ghe.com** side, you need to send the downloaded **Federation Metadata XML** and appropriate copied URLs from Microsoft Entra admin center to [GitHub Enterprise Managed User - ghe.com support team](https://support.github.com/early-access/data-residency). They set this setting to have the SAML SSO connection set properly on both sides.
+To configure single sign-on on **GitHub Enterprise Managed User** side, you need to send the downloaded **Federation Metadata XML** and appropriate copied URLs from Microsoft Entra admin center to [GitHub Enterprise Managed User support team](https://support.github.com/early-access/data-residency). They set this setting to have the SAML SSO connection set properly on both sides.
 
-### Create GitHub Enterprise Managed User - ghe.com test user
+### Create GitHub Enterprise Managed User test user
 
-In this section, you create a user called B.Simon in GitHub Enterprise Managed User - ghe.com. Work with [GitHub Enterprise Managed User - ghe.com support team](https://support.github.com/early-access/data-residency) to add the users in the GitHub Enterprise Managed User - ghe.com platform. Users must be created and activated before you use single sign-on.
+In this section, you create a user called B.Simon in GitHub Enterprise Managed User. Work with [GitHub Enterprise Managed User support team](https://support.github.com/early-access/data-residency) to add the users in the GitHub Enterprise Managed User platform. Users must be created and activated before you use single sign-on.
 
 ## Test SSO 
 
@@ -134,16 +134,16 @@ In this section, you test your Microsoft Entra single sign-on configuration with
  
 #### SP initiated:
  
-* Click on **Test this application** in Microsoft Entra admin center. This will redirect to GitHub Enterprise Managed User - ghe.com Sign-on URL where you can initiate the login flow.  
+* Click on **Test this application** in Microsoft Entra admin center. This will redirect to GitHub Enterprise Managed User Sign-on URL where you can initiate the login flow.  
  
-* Go to GitHub Enterprise Managed User - ghe.com Sign-on URL directly and initiate the login flow from there.
+* Go to GitHub Enterprise Managed User Sign-on URL directly and initiate the login flow from there.
  
 #### IDP initiated:
  
-* Click on **Test this application** in Microsoft Entra admin center and you should be automatically signed in to the GitHub Enterprise Managed User - ghe.com for which you set up the SSO.
+* Click on **Test this application** in Microsoft Entra admin center and you should be automatically signed in to the GitHub Enterprise Managed User for which you set up the SSO.
  
-You can also use Microsoft My Apps to test the application in any mode. When you click the GitHub Enterprise Managed User - ghe.com tile in the My Apps, if configured in SP mode you would be redirected to the application sign-on page for initiating the login flow and if configured in IDP mode, you should be automatically signed in to the GitHub Enterprise Managed User - ghe.com for which you set up the SSO. For more information about the My Apps, see [Introduction to the My Apps](https://support.microsoft.com/account-billing/sign-in-and-start-apps-from-the-my-apps-portal-2f3b1bae-0e5a-4a86-a33e-876fbd2a4510).
+You can also use Microsoft My Apps to test the application in any mode. When you click the GitHub Enterprise Managed User tile in the My Apps, if configured in SP mode you would be redirected to the application sign-on page for initiating the login flow and if configured in IDP mode, you should be automatically signed in to the GitHub Enterprise Managed User for which you set up the SSO. For more information about the My Apps, see [Introduction to the My Apps](https://support.microsoft.com/account-billing/sign-in-and-start-apps-from-the-my-apps-portal-2f3b1bae-0e5a-4a86-a33e-876fbd2a4510).
 
 ## Next steps
 
-Once you configure GitHub Enterprise Managed User - ghe.com you can enforce session control, which protects exfiltration and infiltration of your organization's sensitive data in real time. Session control extends from Conditional Access. [Learn how to enforce session control with Microsoft Defender for Cloud Apps](/cloud-app-security/proxy-deployment-any-app).
+Once you configure GitHub Enterprise Managed User you can enforce session control, which protects exfiltration and infiltration of your organization's sensitive data in real time. Session control extends from Conditional Access. [Learn how to enforce session control with Microsoft Defender for Cloud Apps](/cloud-app-security/proxy-deployment-any-app).

--- a/docs/identity/saas-apps/github-enterprise-managed-user-oidc-provisioning-tutorial.md
+++ b/docs/identity/saas-apps/github-enterprise-managed-user-oidc-provisioning-tutorial.md
@@ -49,23 +49,14 @@ The scenario outlined in this tutorial assumes that you already have the followi
 
 <a name='step-2-configure-github-enterprise-managed-user-oidc-to-support-provisioning-with-azure-ad'></a>
 
-## Step 2: Configure GitHub Enterprise Managed User (OIDC) to support provisioning with Microsoft Entra ID
+## Step 2: Prepare to configure provisioning with Microsoft Entra ID
 
-1. The Tenant URL is `https://api.github.com/scim/v2/enterprises/{enterprise}`. This value will be entered in the Tenant URL field in the Provisioning tab of your GitHub Enterprise Managed User (OIDC) application.
+1. Identify your Tenant URL. This is the value that you will enter in the Tenant URL field in the Provisioning tab of your GitHub Enterprise Managed User application.
+   
+   * For an enterprise on GitHub.com, the Tenant URL is `https://api.github.com/scim/v2/enterprises/{enterprise}`.
+   * For an enterprise on GHE.com, the Tenant URL is `https://api.{subdomain}.ghe.com/scim/v2/enterprises/{subdomain}`
 
-2. As a GitHub Enterprise Managed administrator navigate to the upper-right corner -> click your profile photo -> then click **Settings**.
-
-3. In the left sidebar, click **Developer settings**.
-
-4. In the left sidebar, click **Personal access tokens**.
-
-5. Click **Generate new token**.
-
-6. Select the **admin:enterprise** scope for this token.
-
-7. Click **Generate Token**.
-
-8. Copy and save the **secret token**. This value will be entered in the Secret Token field in the Provisioning tab of your GitHub Enterprise Managed User (OIDC) application.
+2. Ensure you have created a token with the **scim:enterprise** scope for your enterprise's setup user. This value will be entered in the Secret Token field in the Provisioning tab of your GitHub Enterprise Managed User application. See [Getting started with Enterprise Managed Users](https://docs.github.com/en/enterprise-cloud@latest/admin/managing-iam/understanding-iam-for-enterprises/getting-started-with-enterprise-managed-users#create-a-personal-access-token) on GitHub Docs.
 
 <a name='step-3-add-github-enterprise-managed-user-oidc-from-the-azure-ad-application-gallery'></a>
 
@@ -109,11 +100,11 @@ This section guides you through the steps to configure the Microsoft Entra provi
 
 5. Under the **Admin Credentials** section, input your GitHub Enterprise Managed User (OIDC) Tenant URL and Secret Token. Click **Test Connection** to ensure Microsoft Entra ID can connect to GitHub Enterprise Managed User (OIDC). If the connection fails, ensure your GitHub Enterprise Managed User (OIDC) account has created the secret token as an enterprise owner and try again.
 
-   For "Tenant URL", type `https://api.github.com/scim/v2/enterprises/YOUR_ENTERPRISE`, replacing YOUR_ENTERPRISE with the name of your enterprise account.
+   * For "Tenant URL", type the tenant URL you identified earlier.
    
-   For example, if your enterprise account's URL is https://github.com/enterprises/octo-corp, the name of the enterprise account is octo-corp.
+     For example, if your enterprise account's URL is https://github.com/enterprises/octo-corp, the name of the enterprise account is octo-corp.
    
-   For "Secret token", paste the personal access token with the admin:enterprise scope that  you created earlier.
+   * For "Secret token", paste the GitHub personal access token that you created earlier.
    
      ![Token](common/provisioning-testconnection-tenanturltoken.png)
 

--- a/docs/identity/saas-apps/github-enterprise-managed-user-provisioning-tutorial.md
+++ b/docs/identity/saas-apps/github-enterprise-managed-user-provisioning-tutorial.md
@@ -50,23 +50,14 @@ The scenario outlined in this tutorial assumes that you already have the followi
 
 <a name='step-2-configure-github-enterprise-managed-user-to-support-provisioning-with-azure-ad'></a>
 
-## Step 2: Configure GitHub Enterprise Managed User to support provisioning with Microsoft Entra ID
+## Step 2: Prepare to configure provisioning with Microsoft Entra ID
 
-1. The Tenant URL is `https://api.github.com/scim/v2/enterprises/{enterprise}`. This value will be entered in the Tenant URL field in the Provisioning tab of your GitHub Enterprise Managed User application.
+1. Identify your Tenant URL. This is the value that you will enter in the Tenant URL field in the Provisioning tab of your GitHub Enterprise Managed User application.
+   
+   * For an enterprise on GitHub.com, the Tenant URL is `https://api.github.com/scim/v2/enterprises/{enterprise}`.
+   * For an enterprise on GHE.com, the Tenant URL is `https://api.{subdomain}.ghe.com/scim/v2/enterprises/{subdomain}`
 
-2. As a GitHub Enterprise Managed administrator navigates to the upper-right corner -> click your profile photo -> then click **Settings**.
-
-3. In the left sidebar, click **Developer settings**.
-
-4. In the left sidebar, click **Personal access tokens**.
-
-5. Click **Generate new token**.
-
-6. Select the **admin:enterprise** scope for this token.
-
-7. Click **Generate Token**.
-
-8. Copy and save the **secret token**. This value will be entered in the Secret Token field in the Provisioning tab of your GitHub Enterprise Managed User application.
+2. Ensure you have created a token with the **scim:enterprise** scope for your enterprise's setup user. This value will be entered in the Secret Token field in the Provisioning tab of your GitHub Enterprise Managed User application. See [Getting started with Enterprise Managed Users](https://docs.github.com/en/enterprise-cloud@latest/admin/managing-iam/understanding-iam-for-enterprises/getting-started-with-enterprise-managed-users#create-a-personal-access-token) on GitHub Docs.
 
 <a name='step-3-add-github-enterprise-managed-user-from-the-azure-ad-application-gallery'></a>
 


### PR DESCRIPTION
I am told that the app linked from this tutorial is not correct, and customers should use the standard GitHub EMU app for both GitHub.com and GHE.com.

It is useful to keep the guide because it includes the correct URL values for enterprises on GHE.com. I've updated references to the app name and copied the instructions for the installation section from https://github.com/MicrosoftDocs/entra-docs/blob/main/docs/identity/saas-apps/github-enterprise-managed-user-tutorial.md?plain=1.

**NOTE**: We need these updates merged before 29 October?