### PR TITLE
Update pim-resource-roles-assign-roles.md

### DIFF
--- a/docs/id-governance/privileged-identity-management/pim-resource-roles-assign-roles.md
+++ b/docs/id-governance/privileged-identity-management/pim-resource-roles-assign-roles.md
@@ -47,7 +47,7 @@ For more information, see [What is Azure attribute-based access control (Azure A
 
 Follow these steps to make a user eligible for an Azure resource role.
 
-1. Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com) as at least a [User Access Administrator](~/identity/role-based-access-control/permissions-reference.md#user-administrator).
+1. Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com) as at least a User Access Administrator.
 
 1. Browse to **Identity governance** > **Privileged Identity Management** > **Azure resources**.
 


### PR DESCRIPTION
Hi,

This is stated:
"Sign in to the Microsoft Entra admin center as at least a User Access Administrator"

This is correct. The User Access Administrator is a RBAC role but the link:
https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference#user-administrator

Point to the Entra ID role user administrator.

I have removed the link, but it really should point to:
https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/privileged#user-access-administrator

I do not know how to add the link correctly  :-)

Regards Peter
