### PR TITLE
Clarified which protocol the connectivity is required

### DIFF
--- a/docs/identity/authentication/how-to-enable-authenticator-passkey.md
+++ b/docs/identity/authentication/how-to-enable-authenticator-passkey.md
@@ -24,8 +24,8 @@ This article lists steps to enable and enforce use of passkeys in Authenticator 
 - [Microsoft Entra multifactor authentication (MFA)](howto-mfa-getstarted.md)
 - Android 14 and later or iOS 17 and later
 - An active internet connection on any device that is part of the passkey registration/authentication process. Connectivity to these two endpoints must be allowed in your organization to enable cross-device registration and authentication:
-  - cable.ua5v.com
-  - cable.auth.com
+  - https://cable.ua5v.com
+  - https://cable.auth.com
 - For cross-device registration/authentication, both devices must have Bluetooth enabled
 
 > [!NOTE]


### PR DESCRIPTION
The current documentation doesn't state which port/protocol that connectivity is required to `cable.ua5v.com` and `cable.auth.com`. Updated to be https, which implies TCP port 443.