### PR TITLE
Fabric Administrator translated to italian locale in Entra ID misleading

### DIFF
--- a/docs/identity/role-based-access-control/permissions-reference.md
+++ b/docs/identity/role-based-access-control/permissions-reference.md
@@ -1017,6 +1017,7 @@ This is a [privileged role](privileged-roles-permissions.md). This administrator
 
 ## Fabric Administrator
 
+
 Users with this role have global permissions within Microsoft Fabric and Power BI, when the service is present, as well as the ability to manage support tickets and monitor service health. For more information, see [Understanding Fabric admin roles](/fabric/admin/roles).
 
 > [!div class="mx-tableFixed"]


### PR DESCRIPTION
When you set the Azure Entra ID web interface in italian locale the role definition of "Fabric Administrator" is translated into "Amministratore infrastruttura" but this is misleading, because in italian the term "infrastruttura" stands for "infrastructure". When an italian Entra ID Admin searches for "Fabric Administrator" role in the italian web interface it will be more consistent to use the term "Amministratore di Fabric" using the name Fabric as a product name without translating it, the same way as other products "Amministratore di Teams" or "Amministratore di Sharepoint".

![image](https://github.com/user-attachments/assets/b1551789-4641-45ce-a03d-a7f851667018)

Moreover, the documentation is not consistent too:
- in Entra ID docs [https://learn.microsoft.com/it-it/entra/identity/role-based-access-control/permissions-reference?WT.mc_id=Portal-Microsoft_AAD_IAM] we can see that the term "Amministratore di Fabric" is used as we would expect as a correct translation, but obviously you cannot find it in Entra ID web interface so there's a mismatch:
![image](https://github.com/user-attachments/assets/ffdf90dd-3bcf-4359-8e89-f4d2bd30bf5c)
- in Microsoft 365 docs [https://learn.microsoft.com/it-it/microsoft-365/admin/add-users/about-admin-roles?view=o365-worldwide] we can see that the term "Amministratore dell'infrastruttura" is matching with the term in Entra ID web interface, but again the term "Amministratore di Fabric" would be preferred as stated before: 
![image](https://github.com/user-attachments/assets/569fc31a-616b-41cb-84c1-e7bc33575953)

My proposal is to use the more correct and easy to understand term "Amministratore di Fabric" specified in Entra ID docs and apply it in a consistent manner into Entra ID web interface and also Microsoft 365 docs (and any other reference using it aswell).

The actual workaround is to use everything in English locale (docs and Entra ID web interface) just to avoid confusion, but I am opening this request because I received a lot of feedback by our customers that use italian docs and interfaces as a daily routine.
Thanks for your valuable support
Luca Bovo