### PR TITLE
Note to clarify Conditional Access behavior with Require app protection policy grant control

### DIFF
--- a/docs/identity/conditional-access/policy-all-users-windows-app-protection.md
+++ b/docs/identity/conditional-access/policy-all-users-windows-app-protection.md
@@ -62,6 +62,9 @@ The following steps help create a Conditional Access policy requiring an app pro
 1. Confirm your settings and set **Enable policy** to **Report-only**.
 1. Select **Create** to create to enable your policy.
 
+>[!Note]
+>If you set to **Require all the selected controls** or just use the **Require app protection policy** control alone, you need to make sure that you only target unmanaged devices or that the devices are not MDM managed. Otherwise, the policy will block access to all applications since it cannot assess whether the application is compliant as per policy.
+
 After administrators confirm the settings using [report-only mode](howto-conditional-access-insights-reporting.md), they can move the **Enable policy** toggle from **Report-only** to **On**.
 
 > [!TIP]


### PR DESCRIPTION
Added a note to clarify behavior when the there is only the "Require app protection policy" grant control or the "Require all the selected controls" option, where a managed device may be blocked from accessing an application, since it lacks an MAMenrollmentID.

