### PR TITLE
Update domains-verify-custom-subdomain.md

### DIFF
--- a/docs/identity/users/domains-verify-custom-subdomain.md
+++ b/docs/identity/users/domains-verify-custom-subdomain.md
@@ -33,11 +33,12 @@ Because subdomains inherit the authentication type of the root domain by default
 
    ```powershell
    Connect-MgGraph -Scopes "Domain.ReadWrite.All"
-    $param = @{
+   
+   $param = @{
       id="test.contoso.com"
       AuthenticationType="Federated"  
      }
-   New-MgDomain -Name "child.mydomain.com" -Authentication Federated
+   New-MgDomain -BodyParameter $param
    ```
 
 1. Use the following example to GET the domain. Because the domain isn't a root domain, it inherits the root domain authentication type. Your command and results might look as follows, using your own tenant ID:


### PR DESCRIPTION
there is a typo and Name is not a parameter available for New-MgDomain.  I believe the intent of this sample was to pass a parameter object containing the domain id and authenticationType into the New-MgDomain cmdlet