### PR TITLE
Added protocol for endpoints

### DIFF
--- a/docs/identity/authentication/how-to-register-passkey-authenticator.md
+++ b/docs/identity/authentication/how-to-register-passkey-authenticator.md
@@ -158,8 +158,8 @@ Security info by default will prompt users to sign in to the Authenticator app t
 ### Alternate registration flow from Security Info (iOS)
 If a user is unable to sign in to Authenticator to register a passkey, they can fall back to triggering registration directly from Security Info with WebAuthn. If initiating this flow from a browser on a different device, Bluetooth, an internet connection, and connectivity to these two endpoints must be allowed in your organization to enable cross-device registration and authentication:
 
-- cable.ua5v.com
-- cable.auth.com
+- https://cable.ua5v.com
+- https://cable.auth.com
 
 If your organization restricts Bluetooth usage, you can allow cross-device registration of passkeys by permitting Bluetooth pairing exclusively with passkey-enabled FIDO2 authenticators. For more information about how to configure Bluetooth usage only for passkeys, see [Passkeys in Bluetooth-restricted environments](/windows/security/identity-protection/passkeys/?tabs=windows%2Cintune#passkeys-in-bluetooth-restricted-environments).
 
@@ -329,8 +329,8 @@ Security info by default will prompt users to sign in to the Authenticator app t
 
 If a user is unable to sign in to the Authenticator to register a passkey, you can fall back to triggering registration directly from Security Info. If initiating this flow from a browser on a different device, Bluetooth, an internet connection, and connectivity to these two endpoints must be allowed in your organization to enable cross-device registration and authentication:
 
-- cable.ua5v.com
-- cable.auth.com
+- https://cable.ua5v.com
+- https://cable.auth.com
 
 
 If your organization restricts Bluetooth usage, you can allow cross-device registration of passkeys by permitting Bluetooth pairing exclusively with passkey-enabled FIDO2 authenticators. For more information about how to configure Bluetooth usage only for passkeys, see [Passkeys in Bluetooth-restricted environments](/windows/security/identity-protection/passkeys/?tabs=windows%2Cintune#passkeys-in-bluetooth-restricted-environments).

--- a/docs/identity/authentication/passkey-authenticator-faq.yml
+++ b/docs/identity/authentication/passkey-authenticator-faq.yml
@@ -44,8 +44,8 @@ sections:
           Make sure Bluetooth and an active internet connection are enabled on both devices. 
           Additionally, allow connectivity to these two endpoints in your organization to enable cross-device registration and authentication:
           
-          - cable.ua5v.com
-          - cable.auth.com
+          - https://cable.ua5v.com
+          - https://cable.auth.com
       - question: |
           I'm on an Android 14 device and have followed all the steps but I'm not able to register passkeys in the Authenticator app?
         answer: |


### PR DESCRIPTION
Updated the protocol handler for the hostnames, to reflect its a web endpoint (and not SMTP, DNS, POP3 etc protocol).

This helps organisations plan their firewall rules which need the hostname, port and protocol.