### PR TITLE
Fix Azure roles PIM steps

### DIFF
--- a/docs/id-governance/privileged-identity-management/pim-resource-roles-activate-your-roles.yml
+++ b/docs/id-governance/privileged-identity-management/pim-resource-roles-activate-your-roles.yml
@@ -42,7 +42,7 @@ procedureSection:
 
     steps:
       - |
-        Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com) as at least a [Privileged Role Administrator](~/identity/role-based-access-control/permissions-reference.md#privileged-role-administrator).
+        Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com).
       - |
         Browse to **Identity governance** > **Privileged Identity Management** > **My roles**.
 


### PR DESCRIPTION
Activating an Azure role does not require you to be a Privileged Role Administrator. I think the doc is incorrect and it shouldn't state that you have to sign in as a Privileged Role Admin in order to PIM elevate.