### PR TITLE
Update how-to-authentication-external-method-manage.md

### DIFF
--- a/docs/identity/authentication/how-to-authentication-external-method-manage.md
+++ b/docs/identity/authentication/how-to-authentication-external-method-manage.md
@@ -33,6 +33,8 @@ To create an EAM, you need the following information from your external authenti
  
    >[!NOTE]
    >See [Configure a new external authentication provider with Microsoft Entra ID](concept-authentication-external-method-provider.md#configure-a-new-external-authentication-provider-with-microsoft-entra-id) to set up the App registration.
+   >[!IMPORTANT]
+Ensure that the kid (Key ID) property is base64-encoded in both the JWT header of the id_token and in the JSON Web Key Set (JWKS) retrieved from the provider’s jwks_uri. This encoding alignment is essential for the seamless validation of token signatures during authentication processes. Misalignment can result in issues with key matching or signature validation.
 
 ## Manage an EAM in the Microsoft Entra admin center
 

--- a/docs/identity/authentication/how-to-authentication-external-method-manage.md
+++ b/docs/identity/authentication/how-to-authentication-external-method-manage.md
@@ -33,8 +33,9 @@ To create an EAM, you need the following information from your external authenti
  
    >[!NOTE]
    >See [Configure a new external authentication provider with Microsoft Entra ID](concept-authentication-external-method-provider.md#configure-a-new-external-authentication-provider-with-microsoft-entra-id) to set up the App registration.
+   
    >[!IMPORTANT]
-Ensure that the kid (Key ID) property is base64-encoded in both the JWT header of the id_token and in the JSON Web Key Set (JWKS) retrieved from the provider’s jwks_uri. This encoding alignment is essential for the seamless validation of token signatures during authentication processes. Misalignment can result in issues with key matching or signature validation.
+   > Ensure that the kid (Key ID) property is base64-encoded in both the JWT header of the id_token and in the JSON Web Key Set (JWKS) retrieved from the provider’s jwks_uri. This encoding alignment is essential for the seamless validation of token signatures during authentication processes. Misalignment can result in issues with key matching or signature validation.
 
 ## Manage an EAM in the Microsoft Entra admin center
 


### PR DESCRIPTION
The document has been updated to include additional guidance on configuring the OpenID Connect (OIDC) discovery URL for external authentication methods (EAMs). Specifically, it highlights the importance of ensuring that the kid property in both the JWT header of the id_token and the external provider's jwks_uri is base64-encoded. This addition aims to prevent common configuration issues and improve the integration process with external authentication providers.