### PR TITLE
Update certificate-credentials.md

### DIFF
--- a/docs/identity-platform/certificate-credentials.md
+++ b/docs/identity-platform/certificate-credentials.md
@@ -31,7 +31,7 @@ To compute the assertion, you can use one of the many JWT libraries in the langu
 | --- | --- |
 | `alg` | Should be **PS256** |
 | `typ` | Should be **JWT** |
-| `x5t#S256` | Base64url-encoded SHA-256 thumbprint of the X.509 certificate's DER encoding. |
+| `x5t` | Base64url-encoded SHA-256 thumbprint of the X.509 certificate's DER encoding. |
 
 ### Claims (payload)
 
@@ -55,7 +55,7 @@ The signature is computed by applying the certificate as described in the [JSON 
 {
   "alg": "PS256",
   "typ": "JWT",
-  "x5t#S256": "A1bC2dE3fH4iJ5kL6mN7oP8qR9sT0u"
+  "x5t": "A1bC2dE3fH4iJ5kL6mN7oP8qR9sT0u"
 }
 .
 {


### PR DESCRIPTION
The article mentions the attribute x5t#S256 and our internal wiki mentions just x5t. I just tested with a customer and using the x5t the authentication works fine, but if we change it to x5t#S256 the error :"AADSTS700027: The certificate with identifier used to sign the client assertion is not registered on application is returned. 

Please remove the #S256 from the attribute x5t.