### PR TITLE
Changed Entra admin center link to Azure portal link

### DIFF
--- a/docs/workload-id/workload-identity-federation-create-trust-user-assigned-managed-identity.md
+++ b/docs/workload-id/workload-identity-federation-create-trust-user-assigned-managed-identity.md
@@ -43,7 +43,7 @@ To learn more about supported regions, time to propagate federated credential up
 
 ## Configure a federated identity credential on a user-assigned managed identity
 
-In the [Microsoft Entra admin center](https://entra.microsoft.com), navigate to the user-assigned managed identity you created.  Under **Settings** in the left nav bar, select **Federated credentials** and then **Add Credential**.
+In the [Microsoft Azure portal](https://portal.azure.com), navigate to the user-assigned managed identity you created.  Under **Settings** in the left nav bar, select **Federated credentials** and then **Add Credential**.
 
 In the **Federated credential scenario** dropdown box, select your scenario.
 
@@ -157,13 +157,13 @@ Select **Add** to configure the federated credential.
 
 ## List federated identity credentials on a user-assigned managed identity
 
-In the [Microsoft Entra admin center](https://entra.microsoft.com), navigate to the user-assigned managed identity you created.  Under **Settings** in the left nav bar and select **Federated credentials**.
+In the [Microsoft Azure portal](https://portal.azure.com), navigate to the user-assigned managed identity you created.  Under **Settings** in the left nav bar and select **Federated credentials**.
 
 The federated identity credentials configured on that user-assigned managed identity are listed.
 
 ## Delete a federated identity credential from a user-assigned managed identity
 
-In the [Microsoft Entra admin center](https://entra.microsoft.com), navigate to the user-assigned managed identity you created.  Under **Settings** in the left nav bar and select **Federated credentials**.
+In the [Microsoft Azure portal](https://portal.azure.com), navigate to the user-assigned managed identity you created.  Under **Settings** in the left nav bar and select **Federated credentials**.
 
 The federated identity credentials configured on that user-assigned managed identity are listed.
 


### PR DESCRIPTION
The original link was pointing to Entra ID, which does not have the settings in the managed identity's properties. Instead, in the Azure portal, the managed identity contains a Settings section where the instructed configurations can be found.