### PR TITLE
No Role is needed to activate PIM

### DIFF
--- a/docs/id-governance/privileged-identity-management/pim-resource-roles-activate-your-roles.yml
+++ b/docs/id-governance/privileged-identity-management/pim-resource-roles-activate-your-roles.yml
@@ -42,7 +42,7 @@ procedureSection:
 
     steps:
       - |
-        Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com) as at least a [Privileged Role Administrator](~/identity/role-based-access-control/permissions-reference.md#privileged-role-administrator).
+        Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com) 
       - |
         Browse to **Identity governance** > **Privileged Identity Management** > **My roles**.
 


### PR DESCRIPTION
High Privileged role is not needed for users to activate a role in PIM for Azure Ressources.

The documentation is misleading and the entra role `Privileged Role Administrator` is not needed for a normal user to activate PIM.

The role `Privileged Role Administrator` is high privileged and should not be given to many users.