### PR TITLE
Update scopes-oidc.md

### DIFF
--- a/docs/identity-platform/scopes-oidc.md
+++ b/docs/identity-platform/scopes-oidc.md
@@ -58,7 +58,7 @@ For a step by step guide on how to expose scopes in a web API, see [Configure an
 
 ## OpenID Connect scopes
 
-The Microsoft identity platform implementation of OpenID Connect has a few well-defined scopes that are also hosted on Microsoft Graph: `openid`, `email`, `profile`, and `offline_access`. The `address` and `phone` OpenID Connect scopes aren't supported.
+The Microsoft identity platform implementation of OpenID Connect has a few well-defined scopes that are also hosted on Microsoft Graph: `openid`, `email`, `profile`, and `offline_access`. The `address` and `phone` OpenID Connect scopes aren't supported.  These scopes are sometimes optional and considered for ID token enrichment.  These scopes will not always appear in separate lines in a consent prompt to a user.
 
 If you request the OpenID Connect scopes and a token, you get a token to call the [UserInfo endpoint](userinfo.md).
 

--- a/docs/identity-platform/scopes-oidc.md
+++ b/docs/identity-platform/scopes-oidc.md
@@ -58,7 +58,7 @@ For a step by step guide on how to expose scopes in a web API, see [Configure an
 
 ## OpenID Connect scopes
 
-The Microsoft identity platform implementation of OpenID Connect has a few well-defined scopes that are also hosted on Microsoft Graph: `openid`, `email`, `profile`, and `offline_access`. The `address` and `phone` OpenID Connect scopes aren't supported.  These scopes are sometimes optional and considered for ID token enrichment.  These scopes will not always appear in separate lines in a consent prompt to a user.
+The Microsoft identity platform implementation of OpenID Connect has a few well-defined scopes that are also hosted on Microsoft Graph: `openid`, `email`, `profile`, and `offline_access`. The `address` and `phone` OpenID Connect scopes aren't supported. These scopes are sometimes optional and considered for ID token enrichment. These scopes will not always appear in separate lines in a consent prompt to a user.
 
 If you request the OpenID Connect scopes and a token, you get a token to call the [UserInfo endpoint](userinfo.md).
 


### PR DESCRIPTION
I work in Azure Entra ID support and have gotten several requests for clarity on the OIDC scopes.  During a consent prompt, these scopes are not always listed in separate lines so it can appear that scopes are being added that are not consented to.  I am proposing this clarification so that customers do not believe there are any sort of "bundled" permissions.  I also think some clarity should be added around which tokens these scopes are for (ID or Access Tokens).  But that might make things more confusing.