### PR TITLE
Update groups-dynamic-membership.md

### DIFF
--- a/docs/identity/users/groups-dynamic-membership.md
+++ b/docs/identity/users/groups-dynamic-membership.md
@@ -379,7 +379,7 @@ device.objectId -ne null
 
 ## Extension properties and custom extension properties
 
-Extension attributes and custom extension properties are supported as string properties in rules for dynamic membership groups. [Extension attributes](/graph/api/resources/onpremisesextensionattributes) can be synced from on-premises Window Server Active Directory or updated using Microsoft Graph and take the format of "ExtensionAttributeX," where X equals 1 - 15. Multi-value extension properties aren't supported in rules for dynamic membership groups. 
+Extension attributes and custom extension properties are supported as string properties in rules for dynamic membership groups. [Extension attributes](/graph/api/resources/onpremisesextensionattributes) can be synced from on-premises Window Server Active Directory or updated using Microsoft Graph and take the format of "ExtensionAttributeX," where X equals 1 - 15. Multi-value extension properties aren't supported in rules for dynamic membership groups. This limitation applies to both on-premises extension attributes and custom extension properties.
 
 Here's an example of a rule that uses an extension attribute as a property:
 


### PR DESCRIPTION
Updated the note on the support for multi-valued extension properties in dynamic group membership rules. Multi-valued custom extension properties synced from Entra ID Connect have the same limitation as the on-premises extension attributes (`ExtensionAttribute[1-15]`).