### PR TITLE
Update for Access Review's history reports documentation

### DIFF
--- a/docs/id-governance/access-reviews-downloadable-review-history.md
+++ b/docs/id-governance/access-reviews-downloadable-review-history.md
@@ -16,7 +16,7 @@ With access reviews, you can create a downloadable review history to help your o
  
 ## Who can access and request review history
 
-Review history and request review history are available for any user if they're authorized to view access reviews. To see which roles can view and create access reviews, see [What resource types can be reviewed?](deploy-access-reviews.md#what-resource-types-can-be-reviewed). Global Administrator, Privileged Role Administrator, Identity Governance Administrator, User Administrator, Security Reader, Global Reader, and Security Administrator roles can create history reports.
+Review history and request review history are available for any user if they're authorized to view access reviews. To see which roles can view and create access reviews, see [What resource types can be reviewed?](deploy-access-reviews.md#what-resource-types-can-be-reviewed) Global Administrator, Privileged Role Administrator, Identity Governance Administrator, User Administrator, Security Reader, Global Reader, and Security Administrator roles can create history reports.
 
 ## How to create a review history report
 


### PR DESCRIPTION
This update is for the [downloadable history report](https://learn.microsoft.com/en-us/entra/id-governance/access-reviews-downloadable-review-history) documentation. This update is to document the correct roles a user would need to create such reports.