### PR TITLE
Link to App role assignment using Microsoft Graph is not correct

### DIFF
--- a/docs/identity-platform/howto-add-app-roles-in-apps.md
+++ b/docs/identity-platform/howto-add-app-roles-in-apps.md
@@ -72,7 +72,7 @@ Before you can assign app roles to applications, you need to assign yourself as 
 
 ## Assign app roles to applications
 
-After adding app roles in your application, you can assign an app role to a client app by using the Microsoft Entra admin center or programmatically by using [Microsoft Graph](../graph/api/serviceprincipal-post-approleassignments?view=graph-rest-1.0&tabs=http). Assigning an app role to an application shouldn't be confused with [assigning roles to users](../identity/role-based-access-control/manage-roles-portal.md).
+After adding app roles in your application, you can assign an app role to a client app by using the Microsoft Entra admin center or programmatically by using [Microsoft Graph](/graph/api/serviceprincipal-post-approleassignments?view=graph-rest-1.0&tabs=http). Assigning an app role to an application shouldn't be confused with [assigning roles to users](../identity/role-based-access-control/manage-roles-portal.md).
 
 When you assign app roles to an application, you create *application permissions*. Application permissions are typically used by daemon apps or back-end services that need to authenticate and make authorized API call as themselves, without the interaction of a user.
 

--- a/docs/identity-platform/howto-add-app-roles-in-apps.md
+++ b/docs/identity-platform/howto-add-app-roles-in-apps.md
@@ -72,7 +72,7 @@ Before you can assign app roles to applications, you need to assign yourself as 
 
 ## Assign app roles to applications
 
-After adding app roles in your application, you can assign an app role to a client app by using the Microsoft Entra admin center or programmatically by using [Microsoft Graph](https://learn.microsoft.com/en-us/graph/api/serviceprincipal-post-approleassignments?view=graph-rest-1.0&tabs=http). Assigning an app role to an application shouldn't be confused with [assigning roles to users](../identity/role-based-access-control/manage-roles-portal.md).
+After adding app roles in your application, you can assign an app role to a client app by using the Microsoft Entra admin center or programmatically by using [Microsoft Graph](/graph/api/serviceprincipal-post-approleassignments?view=graph-rest-1.0&tabs=http). Assigning an app role to an application shouldn't be confused with [assigning roles to users](../identity/role-based-access-control/manage-roles-portal.md).
 
 When you assign app roles to an application, you create *application permissions*. Application permissions are typically used by daemon apps or back-end services that need to authenticate and make authorized API call as themselves, without the interaction of a user.
 

--- a/docs/identity-platform/howto-add-app-roles-in-apps.md
+++ b/docs/identity-platform/howto-add-app-roles-in-apps.md
@@ -72,7 +72,7 @@ Before you can assign app roles to applications, you need to assign yourself as 
 
 ## Assign app roles to applications
 
-After adding app roles in your application, you can assign an app role to a client app by using the Microsoft Entra admin center or programmatically by using [Microsoft Graph](/graph/api/serviceprincipal-post-approleassignments?view=graph-rest-1.0&tabs=http). Assigning an app role to an application shouldn't be confused with [assigning roles to users](../identity/role-based-access-control/manage-roles-portal.md).
+After adding app roles in your application, you can assign an app role to a client app by using the Microsoft Entra admin center or programmatically by using [Microsoft Graph](../graph/api/serviceprincipal-post-approleassignments?view=graph-rest-1.0&tabs=http). Assigning an app role to an application shouldn't be confused with [assigning roles to users](../identity/role-based-access-control/manage-roles-portal.md).
 
 When you assign app roles to an application, you create *application permissions*. Application permissions are typically used by daemon apps or back-end services that need to authenticate and make authorized API call as themselves, without the interaction of a user.
 

--- a/docs/identity-platform/howto-add-app-roles-in-apps.md
+++ b/docs/identity-platform/howto-add-app-roles-in-apps.md
@@ -72,7 +72,7 @@ Before you can assign app roles to applications, you need to assign yourself as 
 
 ## Assign app roles to applications
 
-After adding app roles in your application, you can assign an app role to a client app by using the Microsoft Entra admin center or programmatically by using [Microsoft Graph](/graph/api/user-post-approleassignments). Assigning an app role to an application shouldn't be confused with [assigning roles to users](../identity/role-based-access-control/manage-roles-portal.md).
+After adding app roles in your application, you can assign an app role to a client app by using the Microsoft Entra admin center or programmatically by using [Microsoft Graph](https://learn.microsoft.com/en-us/graph/api/serviceprincipal-post-approleassignments?view=graph-rest-1.0&tabs=http). Assigning an app role to an application shouldn't be confused with [assigning roles to users](../identity/role-based-access-control/manage-roles-portal.md).
 
 When you assign app roles to an application, you create *application permissions*. Application permissions are typically used by daemon apps or back-end services that need to authenticate and make authorized API call as themselves, without the interaction of a user.
 


### PR DESCRIPTION
This part should redirect to 'Grant an appRoleAssignment to a service principal'(https://learn.microsoft.com/graph/api/serviceprincipal-post-approleassignments) as it is talking about assigning an app role to an application. But it is redirecting to 'Grant an appRoleAssignment to a user'(https://learn.microsoft.com/graph/api/user-post-approleassignments).