### PR TITLE
Update reference-cross-tenant-custom-roles.md

### DIFF
--- a/docs/external-id/reference-cross-tenant-custom-roles.md
+++ b/docs/external-id/reference-cross-tenant-custom-roles.md
@@ -23,7 +23,7 @@ The following actions are recommended for this role.
 
 | Actions |
 | ------- |
-| microsoft.directory.tenantRelationships/standard/read |
+| microsoft.directory/tenantRelationships/standard/read |
 | microsoft.directory/crossTenantAccessPolicy/standard/read |
 | microsoft.directory/crossTenantAccessPolicy/allowedCloudEndpoints/update |
 | microsoft.directory/crossTenantAccessPolicy/basic/update |


### PR DESCRIPTION
This pull request includes a small change to the `docs/external-id/reference-cross-tenant-custom-roles.md` file. The change corrects the action identifier for reading tenant relationships.

* [`docs/external-id/reference-cross-tenant-custom-roles.md`](diffhunk://#diff-e4668dab7d8ba5009cf6355eb546a20c2ef12a337388659a80f6f3d94853a4e3L26-R26): Corrected the action identifier from `microsoft.directory.tenantRelationships/standard/read` to `microsoft.directory/tenantRelationships/standard/read`.updated permission.