### PR TITLE
Update gpad-prereqs.md With helpful link.

### DIFF
--- a/docs/identity/hybrid/includes/gpad-prereqs.md
+++ b/docs/identity/hybrid/includes/gpad-prereqs.md
@@ -44,7 +44,7 @@ The following prerequisites are required to implement provisioning groups to Act
 
 ### Supported groups and scale limits
 The following is supported:
-  - Only cloud created [Security groups](../../../fundamentals/concept-learn-about-groups.md#group-types) are supported
+  - Only cloud created [Security groups](../../../fundamentals/concept-learn-about-groups.md#group-types) are supported. See the attribute filtering's [default security grouping](../cloud-sync/how-to-attribute-mapping-entra-to-active-directory.md#the-default-security-grouping) for more details.
   - These groups can have assigned or dynamic membership groups.
   - These groups can only contain on-premises synchronized users and / or additional cloud created security groups.
   - The on-premises user accounts that are synchronized and are members of this cloud created security group, can be from the same domain or cross-domain, but they all must be from the same forest.


### PR DESCRIPTION
Adding a link to an important page detailing the [default and mandatory scoping for Hybrid Cloud Sync](https://learn.microsoft.com/en-us/entra/identity/hybrid/cloud-sync/how-to-attribute-mapping-entra-to-active-directory#the-default-security-grouping). This page has been extremely helpful in validating scenarios and thought more people might be helped as well. :)
Brought this up in the Security Elite Partner Program's Entra channel:
https://teams.microsoft.com/l/message/19:9659dd0d11a6423eb23b337e21d13352@thread.tacv2/1738297844884?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=d2f7e968-a7fc-4620-9cb8-8428e79c0ee9&parentMessageId=1738297844884&teamName=Security%20Elite%20Partner%20Program&channelName=Entra&createdTime=1738297844884