### PR TITLE
Update workload-identity-federation-considerations.md

### DIFF
--- a/docs/workload-id/workload-identity-federation-considerations.md
+++ b/docs/workload-id/workload-identity-federation-considerations.md
@@ -37,7 +37,7 @@ Federated identity credentials don't consume the Microsoft Entra tenant service 
 Creation of federated identity credentials is currently **not supported** on user-assigned managed identities created in the following regions:
 
 - Malaysia South
-- New Zeland South
+- New Zealand North
 
 Support for creating federated identity credentials on user assigned identities in these regions will be gradually rolled out. 
 Resources in this region which need to use federated identity credentials, can do so by leveraging a user assigned managed identity created in a supported region. 


### PR DESCRIPTION
This pull request includes a minor correction to the `docs/workload-id/workload-identity-federation-considerations.md` file. The change corrects a typographical error in the region name from "New Zeland South" to "New Zealand North."

* Corrected the region name from "New Zeland South" to "New Zealand North" in the `docs/workload-id/workload-identity-federation-considerations.md` file.