### PR TITLE
About the emergency access account exclusions.

### DIFF
--- a/docs/includes/entra-policy-exclude-user.md
+++ b/docs/includes/entra-policy-exclude-user.md
@@ -10,7 +10,7 @@ manager: amycolannino
 ---
 Conditional Access policies are powerful tools, we recommend excluding the following accounts from your policies:
 
-- **Emergency access** or **break-glass** accounts to prevent lockout due to policy misconfiguration. In the unlikely scenario all administrators are locked out, your emergency-access administrative account can be used to log in and take steps to recover access.
-   - More information can be found in the article, [Manage emergency access accounts in Microsoft Entra ID](~/identity/role-based-access-control/security-emergency-access.md).
 - **Service accounts** and **Service principals**, such as the Microsoft Entra Connect Sync Account. Service accounts are non-interactive accounts that aren't tied to any particular user. They're normally used by back-end services allowing programmatic access to applications, but are also used to sign in to systems for administrative purposes. Calls made by service principals won't be blocked by Conditional Access policies scoped to users. Use Conditional Access for workload identities to define policies targeting service principals.
    - If your organization has these accounts in use in scripts or code, consider replacing them with [managed identities](~/identity/managed-identities-azure-resources/overview.md).
+
+


### PR DESCRIPTION
As part of the SFI initiative, I understand that the policy has changed to require emergency access accounts to be protected by conditional access policies with phishing-resistant MFA configured.

URL1: https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/security-emergency-access

URL2: https://learn.microsoft.com/en-us/entra/identity/conditional-access/policy-admin-phish-resistant-mfa 

The URL1 provides instructions on how to configure phishing-resistant MFA for emergency access accounts, and points to the page in 2.

However, URL2 states that emergency access accounts should be excluded from conditional access. These statements are contradictory and may confuse readers.

I think it would be a good idea to remove the recommendation to exclude emergency access accounts from this document.

Thank you for your consideration.