### PR TITLE
Tutorial fix: Clarify bulk operations for SCIM provisioning

### DIFF
--- a/docs/identity/app-provisioning/use-scim-to-provision-users-and-groups.md
+++ b/docs/identity/app-provisioning/use-scim-to-provision-users-and-groups.md
@@ -156,12 +156,12 @@ There are several endpoints defined in the SCIM RFC. You can start with the `/Us
 |/User|Perform CRUD operations on a user object.|
 |/Group|Perform CRUD operations on a group object.|
 |/Schemas|The set of attributes supported by each client and service provider can vary. One service provider might include `name`, `title`, and `emails`, while another service provider uses `name`, `title`, and `phoneNumbers`. The schemas endpoint allows for discovery of the attributes supported.|
-|/Bulk|Bulk operations allow you to perform operations on a large collection of resource objects in a single operation (for example, update memberships for a large group). Bulk operations aren't supported by the Microsoft Entra SCIM implementation. |
+|/Bulk|Bulk operations allow you to perform operations on a large collection of resource objects in a single operation (for example, update memberships for a large group). While we don't support SCIM /Bulk today, this is something we aim to support in the future to help improve performance. |
 |/ServiceProviderConfig|Provides details about the features of the SCIM standard that are supported, for example, the resources that are supported and the authentication method.|
 |/ResourceTypes|Specifies metadata about each resource.|
 
 > [!NOTE]
-> Use the `/Schemas` endpoint to support custom attributes or if your schema changes frequently as it enables a client to retrieve the most up-to-date schema automatically. Use the `/Bulk` endpoint to support groups. However, bulk operations aren't supported by the Microsoft Entra SCIM implementation.
+> Use the `/Schemas` endpoint to support custom attributes or if your schema changes frequently as it enables a client to retrieve the most up-to-date schema automatically. Use the `/Bulk` endpoint to support groups. While we don't support the /Bulk endpoint today, this is something we aim to support in the future to help improve performance.
 
 <a name='understand-the-azure-ad-scim-implementation'></a>
 

--- a/docs/identity/app-provisioning/use-scim-to-provision-users-and-groups.md
+++ b/docs/identity/app-provisioning/use-scim-to-provision-users-and-groups.md
@@ -156,12 +156,12 @@ There are several endpoints defined in the SCIM RFC. You can start with the `/Us
 |/User|Perform CRUD operations on a user object.|
 |/Group|Perform CRUD operations on a group object.|
 |/Schemas|The set of attributes supported by each client and service provider can vary. One service provider might include `name`, `title`, and `emails`, while another service provider uses `name`, `title`, and `phoneNumbers`. The schemas endpoint allows for discovery of the attributes supported.|
-|/Bulk|Bulk operations allow you to perform operations on a large collection of resource objects in a single operation (for example, update memberships for a large group).|
+|/Bulk|Bulk operations allow you to perform operations on a large collection of resource objects in a single operation (for example, update memberships for a large group). Bulk operations aren't supported by the Microsoft Entra SCIM implementation. |
 |/ServiceProviderConfig|Provides details about the features of the SCIM standard that are supported, for example, the resources that are supported and the authentication method.|
 |/ResourceTypes|Specifies metadata about each resource.|
 
 > [!NOTE]
-> Use the `/Schemas` endpoint to support custom attributes or if your schema changes frequently as it enables a client to retrieve the most up-to-date schema automatically. Use the `/Bulk` endpoint to support groups.
+> Use the `/Schemas` endpoint to support custom attributes or if your schema changes frequently as it enables a client to retrieve the most up-to-date schema automatically. Use the `/Bulk` endpoint to support groups. However, bulk operations aren't supported by the Microsoft Entra SCIM implementation.
 
 <a name='understand-the-azure-ad-scim-implementation'></a>
 


### PR DESCRIPTION
The "Develop and plan provisioning for a SCIM endpoint in Microsoft Entra ID" article mentions the /Bulk endpoint, but is missing clarification that bulk operations aren't supported by the Entra SCIM implementation. This change helps to eliminate some confusion due to this documentation, and also improve answers from AI agents (such as ChatGPT and Claude) and search engines.

Preview of changes:
<img width="1032" alt="Screenshot 2025-03-04 at 2 39 40 PM" src="https://github.com/user-attachments/assets/5702261a-3962-47f3-9fd2-efb51b833fea" />

Sources:
* https://learn.microsoft.com/en-us/answers/questions/2125340/microsoft-entra-id-scim-provisioning-bulk
* https://learn.microsoft.com/en-us/answers/questions/1456919/microsoft-entra-id-scim-provisioning-bulk-operatio
* https://learn.microsoft.com/en-us/answers/questions/43996/does-azure-ad-support-bulk-user-group-provisioning
* https://stackoverflow.com/questions/62911088/does-azure-ad-user-provisioning-scim-supports-bulk-operations