### PR TITLE
Fix order based on announcement and testing

### DIFF
--- a/docs/identity/authentication/concept-system-preferred-multifactor-authentication.md
+++ b/docs/identity/authentication/concept-system-preferred-multifactor-authentication.md
@@ -107,8 +107,8 @@ When a user signs in, the authentication process checks which authentication met
 
 1. [Temporary Access Pass](howto-authentication-temporary-access-pass.md)
 1. [Passkey (FIDO2)](concept-authentication-passwordless.md)
-1. [Microsoft Authenticator notifications](concept-authentication-authenticator-app.md)
 1. [External authentication methods](how-to-authentication-external-method-manage.md)
+1. [Microsoft Authenticator notifications](concept-authentication-authenticator-app.md)
 1. [Time-based one-time password (TOTP)](concept-authentication-oath-tokens.md)<sup>1</sup>
 1. [Telephony](concept-authentication-phone-options.md)<sup>2</sup>
 1. [Certificate-based authentication](concept-certificate-based-authentication.md)


### PR DESCRIPTION
The announcement indicates EAM will be preferred over MS Authenticator, and testing has verified this is the case.

Here's the announcement:

![image](https://github.com/user-attachments/assets/8798c92a-35ba-4e6b-8957-6b7a1dec163b)

Recording:

https://github.com/user-attachments/assets/69ebf06e-8bb1-4020-9897-13068b57b330

