### PR TITLE
Update tutorial-enable-security-notifications-for-audit-logs.md

### DIFF
--- a/docs/identity/authentication/tutorial-enable-security-notifications-for-audit-logs.md
+++ b/docs/identity/authentication/tutorial-enable-security-notifications-for-audit-logs.md
@@ -46,8 +46,9 @@ To use this feature, you need:
       >[!NOTE]
       >Only some regions support Zone redundancy. Depending on your location, your Zone redundancy section might be automatically enabled or disabled. For more information, see [Protect logic apps from region failures with zone redundancy and availability zones](/azure/logic-apps/set-up-zone-redundancy-availability-zones).
 
-      :::image type="content" border="true" source="./media/tutorial-enable-security-notifications-for-audit-logs/app-name.png" alt-text="Screenshot of application name.":::
-
+    <!---
+   New Image needed where "Consumption" is selected from the Plan type as instructed
+   -->
     1. Select **Review + create**. Then, review your logic app settings and select **Create**.
     1. Wait for the deployment to be complete.
 


### PR DESCRIPTION
… snapshot

"tutorial enable notifications for audit logs/app-name.png " file contains error in which it is selecting "Standard" plan type instead of "Consumption". A new png file is needed or highlight Consumption in red.


![image](https://github.com/user-attachments/assets/aff6d392-fdba-43da-966c-33ddb4e0d35a)
