### PR TITLE
Make spacing slightly more consistent in FIC HTTP documentation

### DIFF
--- a/docs/identity-platform/v2-oauth2-client-creds-grant-flow.md
+++ b/docs/identity-platform/v2-oauth2-client-creds-grant-flow.md
@@ -200,7 +200,8 @@ Host: login.microsoftonline.com:443
 Content-Type: application/x-www-form-urlencoded
 
 scope=https%3A%2F%2Fgraph.microsoft.com%2F.default
-&client_id=11112222-bbbb-3333-cccc-4444dddd5555&client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer
+&client_id=11112222-bbbb-3333-cccc-4444dddd5555
+&client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer
 &client_assertion=eyJhbGciOiJSUzI1NiIsIng1dCI6Imd4OHRHeXN5amNScUtqRlBuZDdSRnd2d1pJMCJ9.eyJ{a lot of characters here}M8U3bSUKKJDEg
 &grant_type=client_credentials
 ```


### PR DESCRIPTION
Since the earlier HTTP examples in the file all use the convention of putting each new parameter on a new line, an inattentive reader (who might be me) could miss the client_assertion_type field in the previous version of this because it broke that convention. This changes the doc to more uniformly use a newline before every HTTP parameter in the HTTP example blocks.