### PR TITLE
use correct menu to remove permission

### DIFF
--- a/docs/identity-platform/quickstart-configure-app-access-web-apis.md
+++ b/docs/identity-platform/quickstart-configure-app-access-web-apis.md
@@ -138,7 +138,7 @@ The **Grant admin consent** button is *disabled* if you aren't an admin or if no
 It's important not to give an application too many permissions than is necessary. To revoke admin consent for a permission in your application;
 
 1. Navigate to your application and select **API permissions**.
-2. Under **Configured permissions**, select the three dots next to the permission you wish to remove, and select **Remove permission**
+2. Under **Configured permissions**, select the three dots next to the permission you wish to remove, and select **Revoke admin consent**
 3. In the pop-up that appears, select **Yes, remove** to revoke the admin consent for the permission.
 
 ## Related content


### PR DESCRIPTION
When you use "Remove permission" it will actually just remove the permission **request** on the app registration side. But the **granted** permission will remain. To really remove the **granted** permission, you need to use "Revoke admin consent" as it's hinted above "to revoke admin consent for a..." and below "to revoke the admin consent for the..."