### PR TITLE
Update GSA receives traffic on these IP address

### DIFF
--- a/docs/global-secure-access/reference-points-of-presence.md
+++ b/docs/global-secure-access/reference-points-of-presence.md
@@ -103,6 +103,7 @@ The Global Secure Access service receives traffic on these FQDNs and IP addresse
 - `150.171.15.0/24`
 - `150.171.18.0/24`
 - `151.206.0.0/16`
+- `6.6.0.0/16`
  
 ### Global Secure Access egress IP ranges
 Outbound Internet traffic that is acquired by Global Secure Access, including traffic to Microsoft services, will egress from Global Secure Access instances. If the target service uses IP restrictions and access controls, you may need to configure the target service to allow IP connections from Global Secure Access subnets:


### PR DESCRIPTION
According to the Wiki, to use GSA it also needs 6.6.0.0/16 address.

[ref: https://supportability.visualstudio.com/AzureNetworking/_wiki/wikis/Wiki/1475928/-GSA-Client-Coexistence-Guides?anchor=ip-addresses-and-fqdns%3A]

IP Addresses and FQDNs:
*.globalsecureaccess.microsoft.com
13.107.232.0/24
13.107.233.0/24
150.171.15.0/24
150.171.18.0/24
150.171.19.0/24
150.171.20.0/24
151.206.0.0/16
6.6.0.0/16