### PR TITLE
Fix wrong method call in the snippet

### DIFF
--- a/docs/identity-platform/tutorial-single-page-app-react-prepare-app.md
+++ b/docs/identity-platform/tutorial-single-page-app-react-prepare-app.md
@@ -288,7 +288,7 @@ The `msal` packages are used to provide authentication in the application. The `
     // Default to using the first account if no account is active on page load
     if (!msalInstance.getActiveAccount() && msalInstance.getAllAccounts().length > 0) {
         // Account selection logic is app dependent. Adjust as needed for different use cases.
-        msalInstance.setActiveAccount(msalInstance.getActiveAccount()[0]);
+        msalInstance.setActiveAccount(msalInstance.getAllAccounts()[0]);
     }
 
     // Listen for sign-in event and set active account


### PR DESCRIPTION
Fixes a wrong method call in the snippet handling assertion of whether there is a user session available.

It was meant to assign the first found account from getAllAccounts() as active if no active account is set. getActiveAccount doesn't return an array in the first place.