### PR TITLE
Cloud_displayname group claim, for multi-tenant apps

### DIFF
--- a/docs/identity/hybrid/connect/how-to-connect-fed-group-claims.md
+++ b/docs/identity/hybrid/connect/how-to-connect-fed-group-claims.md
@@ -261,6 +261,7 @@ You can also configure group claims in the [optional claims](~/identity-platform
 
    > [!NOTE]
    > If you use `"emit_as_roles"`, any configured application roles that the user is assigned to will not appear in the role claim.
+   > Cloud_displayname for JWT tokens, currently, only works with single-tenant applications. For multi-tenant applications, the group ID will be issued.
 
 ### Examples
 


### PR DESCRIPTION
Documentation should clarify that cloud_displayname will be issued only for single-tenant apps, in JWT tokens. For multi-tenant apps, the group ID will still be issued in the claim, instead of the group name.