### PR TITLE
Update required roles for configuration

### DIFF
--- a/docs/global-secure-access/how-to-compliant-network.md
+++ b/docs/global-secure-access/how-to-compliant-network.md
@@ -31,7 +31,7 @@ The compliant network is different than [IPv4, IPv6, or geographic locations](..
 
 - Administrators who interact with **Global Secure Access** features must have one or more of the following role assignments depending on the tasks they're performing.
    - The [Global Secure Access Administrator role](/azure/active-directory/roles/permissions-reference) role to manage the Global Secure Access features.
-   - [Conditional Access Administrator](../identity/role-based-access-control/permissions-reference.md#conditional-access-administrator) to create and interact with Conditional Access policies and named locations.
+   - [Conditional Access Administrator](../identity/role-based-access-control/permissions-reference.md#conditional-access-administrator) to enable Global Secure Access signaling for Conditional Access, as well as to create and interact with Conditional Access policies and named locations.
 - The product requires licensing. For details, see the licensing section of [What is Global Secure Access](overview-what-is-global-secure-access.md). If needed, you can [purchase licenses or get trial licenses](https://aka.ms/azureadlicense).
 
 ### Known limitations
@@ -42,7 +42,7 @@ The compliant network is different than [IPv4, IPv6, or geographic locations](..
 
 To enable the required setting to allow the compliant network check, an administrator must take the following steps.
 
-1. Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com) as a [Global Secure Access Administrator](../identity/role-based-access-control/permissions-reference.md#global-secure-access-administrator).
+1. Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com) with an account which has the [Global Secure Access Administrator](../identity/role-based-access-control/permissions-reference.md#global-secure-access-administrator) and [Conditional Access Administrator](../identity/role-based-access-control/permissions-reference.md#conditional-access-administrator) role activated.
 1. Browse to **Global Secure Access** > **Settings** > **Session management** > **Adaptive access**.
 1. Select the toggle to **Enable CA Signaling for Entra ID (covering all cloud apps)**. This will automatically enable CAE signaling for Office 365 (preview).
 1. Browse to **Protection** > **Conditional Access** > **Named locations**.


### PR DESCRIPTION
Steps just mentioned the "GSA Admin" role, but in order to active CA Signaling, either one of the following roles is required:
* Company Administrator (which doesn't exists)
* Security Administrator
* Conditional Access Administrator

Least priv role in that case is CA Administrator.