### PR TITLE
Add note about completing successful auth before using QR code auth

### DIFF
--- a/docs/identity/authentication/how-to-authentication-qr-code.md
+++ b/docs/identity/authentication/how-to-authentication-qr-code.md
@@ -41,7 +41,7 @@ This topic covers how to enable the QR code authentication method in the Authent
 
 ## Enable QR code authentication method
 
-You can enable the QR code authentication method by using the Microsoft Entra admin center or Microsoft Graph API. 
+You can enable the QR code authentication method by using the Microsoft Entra admin center or Microsoft Graph API.
 
 ### Enable QR code authentication method in the Microsoft Entra admin center
 
@@ -86,6 +86,9 @@ This example enables QR code authentication for a group, with a PIN length of 10
   ```https
   204 No Response
   ```
+
+> [!NOTE]
+> Once QR code authentication is scoped to a user e.g. via a group, the user must first successfully complete an interactive or non-interactive authentication before the QR code can be used. Whilst most users will likely complete a successful authentication before they use QR code authentication, some may not which will result in an _Incorrect QR code_ error.
 
 ## Add QR code authentication method for a user
 


### PR DESCRIPTION
Whilst testing QR code authentication recently, I ran into an issue where none of my test users could use QR code authentication. After some time, I found one could - seemingly randomly. After working with Microsoft on this issue via email, it was highlighted that the authentication methods for a user are cached and only refreshed after successful authentication using an existing method. As I had scoped QR code auth to these test users and then immediately tried to use it, authentication failed. Once I logged in using a different method first e.g. password, QR code auth then worked for subsequent authentications.

This PR adds a small note to the QR code auth documentation highlighting this subtle and crucial requirement.