### PR TITLE
Fix required permissions to operate Connect Health agent

### DIFF
--- a/docs/identity/hybrid/connect/how-to-connect-health-adfs-risky-ip.md
+++ b/docs/identity/hybrid/connect/how-to-connect-health-adfs-risky-ip.md
@@ -84,7 +84,7 @@ Using the **Download** functionality, the whole risky IP address list in the pas
 
 You can update the report's administrator contacts through the **Notification Settings**. By default, the risky IP alert email notification is in an *off* state. You can enable the notification by toggling the button under **Get email notifications for IP addresses exceeding failed activity threshold report**.
 
-Like generic alert notification settings in Connect Health, it allows you to customize the designated notification recipient list about the Risky IP report from here. You can also notify all Hybrid Identity Administrators while you're making the change. 
+Like generic alert notification settings in Connect Health, it allows you to customize the designated notification recipient list about the Risky IP report from here. You can also notify all Global Administrators while you're making the change. 
 
 ## Configure threshold settings
 

--- a/docs/identity/hybrid/connect/how-to-connect-health-agent-install.md
+++ b/docs/identity/hybrid/connect/how-to-connect-health-agent-install.md
@@ -127,7 +127,7 @@ To start the agent installation, double-click the *.exe* file that you downloade
 
 :::image type="content" source="media/how-to-connect-health-agent-install/aadconnect-health-adds-agent-install1.png" alt-text="Screenshot that shows the Microsoft Entra Connect Health agent for AD DS installation window.":::
 
-When you're prompted, sign in by using a Microsoft Entra account that has permissions to register the agent. By default, the Hybrid Identity Administrator account has permissions.
+When you're prompted, sign in by using a Microsoft Entra account that has permissions to register the agent. By default, the Global Administrator account has permissions.
 
 :::image type="content" source="media/how-to-connect-health-agent-install/install3.png" alt-text="Screenshot that shows the sign-in window for Microsoft Entra Connect Health AD DS.":::
 

--- a/docs/identity/hybrid/connect/how-to-connect-health-operations.md
+++ b/docs/identity/hybrid/connect/how-to-connect-health-operations.md
@@ -33,7 +33,7 @@ You can configure the Microsoft Entra Connect Health service to send email notif
 2. Select **Sync errors**
 3. Select **Notification Settings**.
 5. At the email notification switch, select **ON**.
-6. Select the check box if you want all Hybrid Identity Administrators to receive email notifications.
+6. Select the check box if you want all Global Administrators to receive email notifications.
 7. If you want to receive email notifications at any other email addresses, specify them in the **Additional Email Recipients** box. To remove an email address from this list, right-select the entry and select **Delete**.
 8. To finalize the changes, select **Save**. Changes take effect only after you save.
 
@@ -103,14 +103,14 @@ When you're deleting a service instance, be aware of the following:
 
 [//]: # (Start of RBAC section)
 ## Manage access with Azure RBAC
-[Azure role-based access control (Azure RBAC)](~/identity/role-based-access-control/permissions-reference.md) for Microsoft Entra Connect Health provides access to users and groups other than Hybrid Identity Administrators. Azure RBAC assigns roles to the intended users and groups, and provides a mechanism to limit the Hybrid Identity Administrators within your directory.
+[Azure role-based access control (Azure RBAC)](~/identity/role-based-access-control/permissions-reference.md) for Microsoft Entra Connect Health provides access to users and groups other than Global Administrators. Azure RBAC assigns roles to the intended users and groups, and provides a mechanism to limit the Global Administrators within your directory.
 
 ### Roles
 Microsoft Entra Connect Health supports the following built-in roles:
 
 | Role | Permissions |
 | --- | --- |
-| Owner |Owners can *manage access* (for example, assign a role to a user or group), *view all information* (for example, view alerts) from the portal, and *change settings* (for example, email notifications) within Microsoft Entra Connect Health. <br>By default, Microsoft Entra Hybrid Identity Administrators are assigned this role, and this can't be changed. |
+| Owner |Owners can *manage access* (for example, assign a role to a user or group), *view all information* (for example, view alerts) from the portal, and *change settings* (for example, email notifications) within Microsoft Entra Connect Health. <br>By default, Microsoft Entra Global Administrators are assigned this role, and this can't be changed. |
 | Contributor |Contributors can *view all information* (for example, view alerts) from the portal, and *change settings* (for example, email notifications) within Microsoft Entra Connect Health. |
 | Reader |Readers can *view all information* (for example, view alerts) from the portal within Microsoft Entra Connect Health. |
 

--- a/docs/identity/hybrid/connect/reference-connect-health-user-privacy.md
+++ b/docs/identity/hybrid/connect/reference-connect-health-user-privacy.md
@@ -57,7 +57,7 @@ See [How to remove a service instance from Microsoft Entra Connect Health](how-t
 
 ### Disable data collection and monitoring for all monitored services
 
-Microsoft Entra Connect Health provides the option to stop data collection of *all* registered services in the tenant. We recommend careful consideration and full acknowledgment of all Hybrid Identity Administrators before you take this action. After the process begins, the Microsoft Entra Connect Health service stops receiving, processing, and reporting any data for all of your services. Existing data in Microsoft Entra Connect Health service is retained for no more than 30 days.
+Microsoft Entra Connect Health provides the option to stop data collection of *all* registered services in the tenant. We recommend careful consideration and full acknowledgment of all Global Administrators before you take this action. After the process begins, the Microsoft Entra Connect Health service stops receiving, processing, and reporting any data for all of your services. Existing data in Microsoft Entra Connect Health service is retained for no more than 30 days.
 
 If you want to stop data collection on a specific server, complete the steps to delete a specific server. To stop data collection for a tenant, complete the following steps to stop data collection and delete all services for the tenant:
 


### PR DESCRIPTION
As per https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference#hybrid-identity-administrator, Hybrid Identity Administrator permissions are not enough to install and operate Connect Health agent.

This PR fixes botched permissions during previous mass change https://github.com/MicrosoftDocs/entra-docs/commit/62d770220ef05999747d2e21ee4bf387b6034476.