### PR TITLE
Add note about roleAssignmentApprovals only being available in beta

### DIFF
--- a/docs/id-governance/privileged-identity-management/pim-apis.md
+++ b/docs/id-governance/privileged-identity-management/pim-apis.md
@@ -57,7 +57,7 @@ This is the final iteration of the PIM API. It includes:
   - PIM alerts for Azure Resources in ARM API - Preview.
 
 > [!NOTE]
-> The roleAssignmentApprovals APIs are only available in /beta
+> The roleAssignmentApprovals APIs are only available in /beta.
 
 Having PIM for Microsoft Entra roles in Microsoft Graph API and PIM for Azure Resources in ARM API provide a few benefits including:
   - Alignment of the PIM APIs for regular role assignment for both Microsoft Entra roles and Azure Resource roles. 

--- a/docs/id-governance/privileged-identity-management/pim-apis.md
+++ b/docs/id-governance/privileged-identity-management/pim-apis.md
@@ -56,6 +56,9 @@ This is the final iteration of the PIM API. It includes:
   - PIM alerts for Microsoft Entra roles in Microsoft Graph API - Preview.
   - PIM alerts for Azure Resources in ARM API - Preview.
 
+> [!NOTE]
+> The roleAssignmentApprovals APIs are only available in /beta
+
 Having PIM for Microsoft Entra roles in Microsoft Graph API and PIM for Azure Resources in ARM API provide a few benefits including:
   - Alignment of the PIM APIs for regular role assignment for both Microsoft Entra roles and Azure Resource roles. 
   - Reducing the need to call other PIM APIs to onboard a resource, get a resource, or get role definition. 


### PR DESCRIPTION
This PR is to make it clear that while the PIM APIs are Generally Available (GA), the roleAssignmentApprovals API is only available in beta. These changes come from some confusion a PIM customer experienced while working with these APIs.