### PR TITLE
Fix typo in cmdlet function name

### DIFF
--- a/docs/identity/authentication/howto-authentication-passwordless-security-key-on-premises.md
+++ b/docs/identity/authentication/howto-authentication-passwordless-security-key-on-premises.md
@@ -107,7 +107,7 @@ Run the following steps in each domain and forest in your organization that cont
 
 ### Select Azure Cloud (Default is Azure Commercial)
 
-By default the `Set-AzureADKerberosSever` cmdlet will use the Commercial cloud endpoints. If you are configuring Kerberos in another cloud environment, you need to set the cmdlet to use the specified cloud.  
+By default the `Set-AzureADKerberosServer` cmdlet will use the Commercial cloud endpoints. If you are configuring Kerberos in another cloud environment, you need to set the cmdlet to use the specified cloud.  
 
 To get a **list** of the available clouds and the numeric value needed to change, run the following:  
 `Get-AzureADKerberosServerEndpoint`  


### PR DESCRIPTION
There is a typo in the word "Server", the command Set-AzureADKerberos**Sever** should be Set-AzureADKerberos**Server**