### PR TITLE
Update concept-sspr-policy.md

### DIFF
--- a/docs/identity/authentication/concept-sspr-policy.md
+++ b/docs/identity/authentication/concept-sspr-policy.md
@@ -50,6 +50,7 @@ The following Microsoft Entra password policy options are defined. Unless noted,
 | Password expiry (Let passwords never expire) |Default value: **false** (indicates that passwords have an expiration date).<br>The value can be configured for individual user accounts by using the [Update-MgUser](/powershell/module/microsoft.graph.users/update-mguser) cmdlet. |
 | Password change history | The last password *can't* be used again when the user changes a password. |
 | Password reset history | The last password *can* be used again when the user resets a forgotten password. |
+**Important:** The password change history in the above table applies to passwrd writeback. For users in  the cloud only, reset password or Entra ID does not have the user's old password and as such cannot check for the same and prevent password reuse.
 
 If you enable *EnforceCloudPasswordPolicyForPasswordSyncedUsers*, the Microsoft Entra password policy applies to user accounts synchronized from on-premises using Microsoft Entra Connect. In addition, if a user changes a password on-premises to include a unicode character, the password change may succeed on-premises but not in Microsoft Entra ID. If password hash synchronization is enabled with Microsoft Entra Connect, the user can still receive an access token for cloud resources. But if the tenant enables [User risk-based password change](~/identity/conditional-access/policy-risk-based-user.md), the password change is reported as high risk. 
 


### PR DESCRIPTION
We have tested few scenarios where the user that is created in the cloud with no on-prem footprint can always reset their password using their old password. No matter where they reset they can re-use the same password over and over even after expiration.

This is because Entra ID does not store user's password, therefore when a user tries to reset their password and use their immediate old password, they are still able to reset.

The table in this document indicates that it shouldn't be possible and customers are opening support cases on. But this only applies when the user is synced from on-prem and tries to do password writeback.

password change history	The last password can't be used again when the user changes a password. Password reset history	The last password can be used again when the user resets a forgotten password.