### PR TITLE
'Personal Microsoft accounts only' cannot be an option.md

### DIFF
--- a/docs/external-id/customers/how-to-microsoft-accounts-federation-customers.md
+++ b/docs/external-id/customers/how-to-microsoft-accounts-federation-customers.md
@@ -37,7 +37,7 @@ To enable sign-in for users with a Microsoft account, you need to create an appl
 1. Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com) as at least a [Cloud Application Administrator](~/identity/role-based-access-control/permissions-reference.md#cloud-application-administrator).
 1. Browse to **Entra ID** > **App registrations** then select **New registration**.
 1. Name the application, for example *ContosoApp*.
-1. Under **Supported account types**, select _Personal Microsoft accounts only_.
+1. Under **Supported account types**, select _Accounts in any organizational directory (Any Microsoft Entra ID tenant - Multitenant) and personal Microsoft accounts (e.g. Skype, Xbox)_.
 1. Under **Redirect URI**, select **Web** and enter your populated redirect URI explained [here](/entra/external-id/customers/how-to-custom-oidc-federation-customers#set-up-your-openid-connect-identity-provider)
 1. Select **Register**.
 


### PR DESCRIPTION
When 'Personal Microsoft accounts only' is chosen, Enterprise app(Service principal object) is not created. So when users tries to attach the app to the user flow, there is no app because user flow only shows Enterprise app(Service principal object).