### PR TITLE
Remove App directory from angular quickstart

### DIFF
--- a/docs/identity-platform/quickstart-single-page-app-sign-in.md
+++ b/docs/identity-platform/quickstart-single-page-app-sign-in.md
@@ -206,7 +206,7 @@ Run the project with a web server by using Node.js:
 1. To start the server, run the following commands from within the project directory:
 
     ```console
-    cd angular-spa/App
+    cd angular-spa
     npm install
     npm start
     ```


### PR DESCRIPTION
Angular quickstart source code is not in `App` subdirectory

![image](https://github.com/user-attachments/assets/e64c8a17-8376-4916-b0be-9cc118e1ce4b)
