### PR TITLE
Clarifying the MFA registration campaign doc

### DIFF
--- a/docs/identity/authentication/how-to-mfa-registration-campaign.md
+++ b/docs/identity/authentication/how-to-mfa-registration-campaign.md
@@ -14,7 +14,7 @@ ms.custom: sfi-ga-nochange, sfi-image-nochange
 
 # How to run a registration campaign to set up Microsoft Authenticator
 
-You can nudge users to set up Microsoft Authenticator during sign-in. Users go through their regular sign-in, perform multifactor authentication as usual, and then get prompted to set up Microsoft Authenticator. You can include or exclude users or groups to control who gets nudged to set up the app. This allows targeted campaigns to move users from less secure authentication methods to Authenticator.  
+You can nudge users to set up Microsoft Authenticator during sign-in if they are using a less secure MFA method, like voice call or SMS. Users go through their regular sign-in, perform multifactor authentication as usual, and then get prompted to set up Microsoft Authenticator. You can include or exclude users or groups to control who gets nudged to set up the app. This allows targeted campaigns to move users from less secure authentication methods to Authenticator.
 
 You can also define how many days a user can postpone, or "snooze," the nudge. If a user taps **Skip for now** to postpone the app setup, they get nudged again on the next MFA attempt after the snooze duration has elapsed. You can decide whether the user can snooze indefinitely or up to three times (after which registration is required).
 


### PR DESCRIPTION
We recently tried to implement this MFA campaign at a customer and struggled with the execution.  We thought the MFA campaign would help onboard ALL users to register an **initial** MFA method, but after many hours, we realized the registration campaign was only designed to step-up users from weaker MFA methods.

We thought adding that wording to the doc would save other customers from time and frustration.

Here is a reddit article that demonstrates some of the frustrations.
https://www.reddit.com/r/AZURE/comments/1j0cmgu/entra_registration_campaign_moving_too_slowly/