### PR TITLE
Update overview.md with fully worded term for managed identities

### DIFF
--- a/docs/identity/managed-identities-azure-resources/overview.md
+++ b/docs/identity/managed-identities-azure-resources/overview.md
@@ -42,15 +42,15 @@ There are two types of managed identities:
   - A service principal of a special type is created in Microsoft Entra ID for the identity. The service principal is tied to the lifecycle of that Azure resource. When the Azure resource is deleted, Azure automatically deletes the service principal for you.
   - By design, only that Azure resource can use this identity to request tokens from Microsoft Entra ID.
   - You authorize the managed identity to have access to one or more services.
-  - The name of the system-assigned service principal is always the same as the name of the Azure resource it's created for. For a deployment slot, the name of its system-assigned identity is ```<app-name>/slots/<slot-name>```.
+  - The name of the system-assigned service principal is always the same as the name of the Azure resource it's created for. For a deployment slot, the name of its system-assigned managed identity is ```<app-name>/slots/<slot-name>```.
 
 - **User-assigned**. You may also create a managed identity as a standalone Azure resource. You can [create a user-assigned managed identity](./how-manage-user-assigned-managed-identities.md?pivots=identity-mi-methods-azp) and assign it to one or more Azure Resources. When you enable a user-assigned managed identity:
 
   - A service principal of a special type is created in Microsoft Entra ID for the identity. The service principal is managed separately from the resources that use it. 
-  - User-assigned identities can be used by multiple resources.
+  - User-assigned managed identities can be used by multiple resources.
   - You authorize the managed identity to have access to one or more services.
 
-  User-assigned identities, which are provisioned independently from compute and can be assigned to multiple compute resources, are the recommended managed identity type for Microsoft services.
+  User-assigned managed identities, which are provisioned independently from compute and can be assigned to multiple compute resources, are the recommended managed identity type for Microsoft services.
 
 Resources that support system assigned managed identities allow you to:
 


### PR DESCRIPTION
Used full term "x-assigned managed identity" instead of a rare "x-assigned identity".