### PR TITLE
Add MFA Registration Policy Link

### DIFF
--- a/docs/identity/authentication/how-to-mfa-registration-campaign.md
+++ b/docs/identity/authentication/how-to-mfa-registration-campaign.md
@@ -26,7 +26,7 @@ You can also define how many days a user can postpone, or "snooze," the nudge. I
 - Your organization must have enabled Microsoft Entra multifactor authentication. Every edition of Microsoft Entra ID includes Microsoft Entra multifactor authentication. No other license is needed for a registration campaign.
 - Users can't have already set up the Authenticator app for push notifications on their account. 
 - Admins need to enable users for the Authenticator app using one of these policies:  
-  - MFA Registration Policy: Users will need to be enabled for **Notification through mobile app**, see [Configure the MFA registration policy](https://learn.microsoft.com/en-us/entra/id-protection/howto-identity-protection-configure-mfa-policy)  
+  - MFA Registration Policy: Users will need to be enabled for **Notification through mobile app**. See [Configure the MFA registration policy](/entra/id-protection/howto-identity-protection-configure-mfa-policy).
   - Authentication Methods Policy: Users will need to be enabled for the Authenticator app and the Authentication mode set to **Any** or **Push**. If the policy is set to **Passwordless**, the user won't be eligible for the nudge. For more information about how to set the Authentication mode, see [Enable passwordless sign-in with Microsoft Authenticator](howto-authentication-passwordless-phone.md). 
 
 ## User experience


### PR DESCRIPTION
Adding a direct link to the documentation for configuring the MFA Registration Policy. This is critical for the MFA registration campaign