### PR TITLE
Update amazon-business-provisioning-tutorial

### DIFF
--- a/docs/identity/saas-apps/amazon-business-provisioning-tutorial.md
+++ b/docs/identity/saas-apps/amazon-business-provisioning-tutorial.md
@@ -117,6 +117,7 @@ This section guides you through the steps to configure the Microsoft Entra provi
    |Japan|https://jp.business-api.amazon.com/scim/v2/|https://www.amazon.co.jp/b2b/abws/oauth?state=1&redirect_uri=https://portal.azure.com/TokenAuthorize&applicationId=amzn1.sp.solution.ee27ec8c-1ee9-4c6b-9e68-26bdc37479d3|
    |Mexico|https://na.business-api.amazon.com/scim/v2/|https://www.amazon.com.mx/b2b/abws/oauth?state=1&redirect_uri=https://portal.azure.com/TokenAuthorize&applicationId=amzn1.sp.solution.ee27ec8c-1ee9-4c6b-9e68-26bdc37479d3|
    |US|https://na.business-api.amazon.com/scim/v2/|https://www.amazon.com/b2b/abws/oauth?state=1&redirect_uri=https://portal.azure.com/TokenAuthorize&applicationId=amzn1.sp.solution.ee27ec8c-1ee9-4c6b-9e68-26bdc37479d3|
+   |Australia|https://jp.business-api.amazon.com/scim/v2/|https://www.amazon.com.au/b2b/abws/oauth?state=1&redirect_uri=https://portal.azure.com/TokenAuthorize&applicationId=amzn1.sp.solution.ee27ec8c-1ee9-4c6b-9e68-26bdc37479d3|
 
 1. In the **Notification Email** field, enter the email address of a person or group who should receive the provisioning error notifications and select the **Send an email notification when a failure occurs** check box.
 


### PR DESCRIPTION
While testing the provisioning flow for Australia and Amazon Business, I noticed the Provisioning documentation (https://learn.microsoft.com/en-us/entra/identity/saas-apps/amazon-business-provisioning-tutorial) does not have the authorization endpoint information needed for Australia.

I have updated the documentation for "Configure Amazon Business for automatic user provisioning with Microsoft Entra ID" to include the new Tenant URL and Authorization endpoint for Australia.

_Note: Australia falls under the "JP" region._