### PR TITLE
Add a link to federation creds to cross-tenant MI FAQ

### DIFF
--- a/docs/identity/managed-identities-azure-resources/managed-identities-faq.md
+++ b/docs/identity/managed-identities-azure-resources/managed-identities-faq.md
@@ -123,7 +123,7 @@ No, if you move a subscription to another directory, you have to manually re-cre
 No, managed identities don't natively support cross-directory scenarios.
 
 However, you can achieve cross-tenant access without need to manage credentials by using Workload Identity Federation. This approach allows you to configure a trust relationship between a managed identity in one tenant and an application in another tenant: [Configure an application to trust a managed identity
-](entra/workload-id/workload-identity-federation-config-app-trust-managed-identity).
+](~/workload-id/workload-identity-federation-config-app-trust-managed-identity.md).
 
 ### Are there any rate limits that apply to managed identities?
 

--- a/docs/identity/managed-identities-azure-resources/managed-identities-faq.md
+++ b/docs/identity/managed-identities-azure-resources/managed-identities-faq.md
@@ -120,7 +120,10 @@ No, if you move a subscription to another directory, you have to manually re-cre
 
 ### Can I use a managed identity to access a resource in a different directory/tenant?
 
-No, managed identities don't currently support cross-directory scenarios. 
+No, managed identities don't natively support cross-directory scenarios.
+
+However, you can achieve cross-tenant access without need to manage credentials by using Workload Identity Federation. This approach allows you to configure a trust relationship between a managed identity in one tenant and an application in another tenant: [Configure an application to trust a managed identity
+](entra/workload-id/workload-identity-federation-config-app-trust-managed-identity).
 
 ### Are there any rate limits that apply to managed identities?
 

--- a/docs/identity/managed-identities-azure-resources/managed-identities-faq.md
+++ b/docs/identity/managed-identities-azure-resources/managed-identities-faq.md
@@ -122,8 +122,7 @@ No, if you move a subscription to another directory, you have to manually re-cre
 
 No, managed identities don't natively support cross-directory scenarios.
 
-However, you can achieve cross-tenant access without the need to manage credentials by using Workload Identity Federation. This approach allows you to configure a trust relationship between a managed identity in one tenant and an application in another tenant: [Configure an application to trust a managed identity
-](~/workload-id/workload-identity-federation-config-app-trust-managed-identity.md).
+However, you can achieve cross-tenant access without the need to manage credentials by using Workload Identity Federation. This approach allows you to configure a trust relationship between a managed identity in one tenant and an application in another tenant: [Configure an application to trust a managed identity](~/workload-id/workload-identity-federation-config-app-trust-managed-identity.md).
 
 ### Are there any rate limits that apply to managed identities?
 

--- a/docs/identity/managed-identities-azure-resources/managed-identities-faq.md
+++ b/docs/identity/managed-identities-azure-resources/managed-identities-faq.md
@@ -122,7 +122,7 @@ No, if you move a subscription to another directory, you have to manually re-cre
 
 No, managed identities don't natively support cross-directory scenarios.
 
-However, you can achieve cross-tenant access without need to manage credentials by using Workload Identity Federation. This approach allows you to configure a trust relationship between a managed identity in one tenant and an application in another tenant: [Configure an application to trust a managed identity
+However, you can achieve cross-tenant access without the need to manage credentials by using Workload Identity Federation. This approach allows you to configure a trust relationship between a managed identity in one tenant and an application in another tenant: [Configure an application to trust a managed identity
 ](~/workload-id/workload-identity-federation-config-app-trust-managed-identity.md).
 
 ### Are there any rate limits that apply to managed identities?


### PR DESCRIPTION
Add a link to [Configure an application to trust a managed identity
](https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation-config-app-trust-managed-identity?tabs=microsoft-entra-admin-center%2Cdotnet) to the FAQ question "Can I use a managed identity to access a resource in a different directory/tenant?" 