### PR TITLE
Update v2-oauth2-client-creds-grant-flow.md

### DIFF
--- a/docs/identity-platform/v2-oauth2-client-creds-grant-flow.md
+++ b/docs/identity-platform/v2-oauth2-client-creds-grant-flow.md
@@ -26,6 +26,8 @@ This article describes how to program directly against the protocol in your appl
 
 For a higher level of assurance, the Microsoft identity platform also allows the calling service to authenticate using a [certificate](#second-case-access-token-request-with-a-certificate) or federated credential instead of a shared secret.  Because the application's own credentials are being used, these credentials must be kept safe. *Never* publish that credential in your source code, embed it in web pages, or use it in a widely distributed native application. 
 
+For a higher level of assurance, the Microsoft identity platform also allows the calling service to authenticate using a [certificate](#second-case-access-token-request-with-a-certificate) or federated credential instead of a shared secret.  Because the application's own credentials are being used, these credentials must be kept safe. *Never* publish that credential in your source code, embed it in web pages, or use it in a widely distributed native application. Authentication requests using the client credentials flow with web pages will not be allowed.
+
 ## Protocol diagram
 
 The entire client credentials flow looks similar to the following diagram. We describe each of the steps later in this article.


### PR DESCRIPTION
The proposed change is for this following paragraph - adding more clarity at the end of the paragraph:

"For a higher level of assurance, the Microsoft identity platform also allows the calling service to authenticate using a certificate or federated credential instead of a shared secret. Because the application's own credentials are being used, these credentials must be kept safe. Never publish that credential in your source code, embed it in web pages, or use it in a widely distributed native application."

The proposed change:
Adding "Authentication requests using the client credentials flow with web pages will not be allowed"

The reason for the change suggestion:
Customer is seeing ambiguity in this article, and they don't see any wording stating that "a client secret should not be passed in a web app for the flow".

Suggestion is to update the public documentation by explicitly stating that authentication requests using the client credentials flow with web pages will not be allowed.