### PR TITLE
macOS: New uninstall localtion (Version 1.1.25060400)

### DIFF
--- a/docs/global-secure-access/how-to-install-macos-client.md
+++ b/docs/global-secure-access/how-to-install-macos-client.md
@@ -198,7 +198,7 @@ Or
 
 -	Run the following command:
 
-`sudo /Applications/Global\ Secure\ Access\ Client.app/Contents/Resources/install_scripts/uninstall`
+`sudo /Applications/GlobalSecureAccessClient/Global\ Secure\ Access\ Client.app/Contents/Resources/install_scripts/uninstall`
 
 If you're using an MDM, uninstall the client with the MDM.
 


### PR DESCRIPTION
This is the command for the new location: `sudo /Applications/GlobalSecureAccessClient/Global\ Secure\ Access\ Client.app/Contents/Resources/install_scripts/uninstall`

The online version still contains: `sudo /Applications/Global\ Secure\ Access\ Client.app/Contents/Resources/install_scripts/uninstall`