### PR TITLE
Update single-and-multi-tenant-apps.md

### DIFF
--- a/docs/identity-platform/single-and-multi-tenant-apps.md
+++ b/docs/identity-platform/single-and-multi-tenant-apps.md
@@ -28,7 +28,7 @@ When you register an application, you can configure it to be single-tenant or mu
 
 | Audience | Single/multi-tenant | Who can sign in |
 | -------- | ------------------- | --------------- |
-| Accounts in this directory only | Single tenant | All user and guest accounts in your directory can use your application or API.<br>Use this option if your target audience is internal to your organization. |
+| Accounts in this directory only | Single tenant | All user and guest accounts in your directory can use your application or API.<br>Use this option if your target audience is internal to your organization. <br> Use if building an app registration for a 3rd party that instructs you to build your own App Registration for their app. |
 | Accounts in any Microsoft Entra directory | Multitenant | All users and guests with a work or school account from Microsoft can use your application or API. This includes schools and businesses that use Microsoft 365.<br>Use this option if your target audience is business or educational customers. |
 | Accounts in any Microsoft Entra directory and personal Microsoft accounts (such as Skype, Xbox, Outlook.com) | Multitenant | All users with a work or school, or personal Microsoft account can use your application or API. It includes schools and businesses that use Microsoft 365 as well as personal accounts that are used to sign in to services like Xbox and Skype.<br>Use this option to target the widest set of Microsoft accounts. |
 

--- a/docs/identity-platform/single-and-multi-tenant-apps.md
+++ b/docs/identity-platform/single-and-multi-tenant-apps.md
@@ -28,7 +28,7 @@ When you register an application, you can configure it to be single-tenant or mu
 
 | Audience | Single/multi-tenant | Who can sign in |
 | -------- | ------------------- | --------------- |
-| Accounts in this directory only | Single tenant | All user and guest accounts in your directory can use your application or API.<br>Use this option if your target audience is internal to your organization. <br> Use if building an app registration for a 3rd party that instructs you to build your own App Registration for their app. |
+| Accounts in this directory only | Single tenant | All user and guest accounts in your directory can use your application or API.<br>Use this option if your target audience is internal to your organization. <br> Use if building an app registration for a third party that instructs you to build your own app registration for their app. |
 | Accounts in any Microsoft Entra directory | Multitenant | All users and guests with a work or school account from Microsoft can use your application or API. This includes schools and businesses that use Microsoft 365.<br>Use this option if your target audience is business or educational customers. |
 | Accounts in any Microsoft Entra directory and personal Microsoft accounts (such as Skype, Xbox, Outlook.com) | Multitenant | All users with a work or school, or personal Microsoft account can use your application or API. It includes schools and businesses that use Microsoft 365 as well as personal accounts that are used to sign in to services like Xbox and Skype.<br>Use this option to target the widest set of Microsoft accounts. |
 


### PR DESCRIPTION
This needs more info on what each of these do. Ex: 

- setting an app registration to multi-tenant allows tenants globally to access the app registration, if ______ . Use this if you want to make your app public, and make your app registration available under Enterprise Apps of 3rd parties.
- setting an app to single-tenant creates a Enterprise App for your tenant only, and should be used when creating apps for 3rd party apps 

(correct as needed)

Stumbled upon my 5th or 6th 3rd party 'SSO Setup' document that instructs users to create their own App Registration for  their app, as multi-tenant. It looked eerily familiar to me, so I reviewed some past docs - it looks like it they were both copy-pasted from the same source.... As in, dev a and dev b copied instructions for registering their OWN public app, and passed those instructions onto customers without fully understanding. I assumed this meant 'available to any connected tenants' for the first few times I did this, and only now am digging further. Having not gone through my own public app deployment process yet, I am not 100% certain on this - but it seems ... wrong for every random tenant to be setting up an App Registration that is open to everyone. 

I'm assuming there is additional config that keeps someone in China from signing into my 3rd party app's registration using their tenant credentials, or from there being hundreds of duplicate registrations. But based off the 5 docs that have the same line/image copy-pasted, I get the feeling this IS being misconfigured a lot - and it gives really exploitable vibes.