### PR TITLE
Add additional note to provide empty "claims" object if no additional claims is expected.

### DIFF
--- a/docs/identity-platform/custom-claims-provider-reference.md
+++ b/docs/identity-platform/custom-claims-provider-reference.md
@@ -156,6 +156,23 @@ In the HTTP response, provide the following JSON document, where the claims `Dat
 }
 ```
 
+If no additional claim have to be returned, provide an empty `claims` object:
+
+```json
+{
+    "data": {
+        "@odata.type": "microsoft.graph.onTokenIssuanceStartResponseData",
+        "actions": [
+            {
+                "@odata.type": "microsoft.graph.tokenIssuanceStart.provideClaimsForToken",
+                "claims": {
+                }
+            }
+        ]
+    }
+}
+```
+
 ### Supported data types
 
 The following table shows the data types supported by Custom claims providers for the token issuance start event:


### PR DESCRIPTION
I created a custom claims provider which do not return additional claims (I used the *TokenIssuanceStart* event to perform only initialization in our application database).

When no additional claims need to be returned, the object in the JSON property `claims` must exist (empty object).