### PR TITLE
Adding documentation support says should be in this article?

### DIFF
--- a/docs/identity/role-based-access-control/security-emergency-access.md
+++ b/docs/identity/role-based-access-control/security-emergency-access.md
@@ -29,7 +29,8 @@ An organization might need to use an emergency access account in the following s
 - The person with the most recent Global Administrator access has left the organization. Microsoft Entra ID prevents the last Global Administrator account from being deleted, but it doesn't prevent the account from being deleted or disabled on-premises. Either situation might make the organization unable to recover the account.
 - Unforeseen circumstances such as a natural disaster emergency, during which a mobile phone or other networks might be unavailable.
 - If role assignments for Global Administrator and Privileged Role Administrator roles are eligible, approval is required for activation, but no approvers are selected (or all approvers are removed from the directory). Active Global Administrators and Privileged Role Administrators are default approvers. But there will be no active Global Administrators and Privileged Role Administrators and administration of the tenant will effectively be locked, unless emergency access accounts are used.
-- Organization has unlicensed Global Administrators who need to receive admin Email Notifications. Only licensed Global Admininstrator accounts receive email notifications and using a mail-enabled break glass account to forward mail to unlicensed Global Administrors is the recommended solution.
+- Global Administrators are using separate unlicensed admin accounts which do not receive Admin Email Notifications.
+- Global Administrators are using Privilaged Identity Management (PIM) for **just-in-time** access to admininistrative roles such as Global Administrator and also need to receive Admin Email Notifications.
 
 ## Create emergency access accounts
 
@@ -58,10 +59,12 @@ Create two or more emergency access accounts. These accounts should be cloud-onl
 
 1. [Validate accounts regularly](#validate-accounts-regularly).
 
-## Forward Admin Email Notifications to administrators using PIM or with separate unlicensed global admin accounts
-1. Make the account a shared mailbox
+## Forward Admin Email Notifications
+This workaround is only intended for customers using [PIM](/entra/id-governance/privileged-identity-management/pim-configure) and/or [separate administrator accounts](/microsoft-365/business-premium/m365bp-protect-admin-accounts?view=o365-worldwide&source=docs#protect-admin-accounts)
+
+1. Make the break-glass account a shared mailbox
    
-1. Create a distribution group containing the licensed user account for users who use PIM or have seaprate unlicensed admin accounts
+1. Create a Distribution List and add the licensed user accounts of any administrators using PIM and/or separate administraor accounts.
    
 1. Forward mail from the breakglass account to the distribution group created in the step above
 

--- a/docs/identity/role-based-access-control/security-emergency-access.md
+++ b/docs/identity/role-based-access-control/security-emergency-access.md
@@ -29,6 +29,7 @@ An organization might need to use an emergency access account in the following s
 - The person with the most recent Global Administrator access has left the organization. Microsoft Entra ID prevents the last Global Administrator account from being deleted, but it doesn't prevent the account from being deleted or disabled on-premises. Either situation might make the organization unable to recover the account.
 - Unforeseen circumstances such as a natural disaster emergency, during which a mobile phone or other networks might be unavailable.
 - If role assignments for Global Administrator and Privileged Role Administrator roles are eligible, approval is required for activation, but no approvers are selected (or all approvers are removed from the directory). Active Global Administrators and Privileged Role Administrators are default approvers. But there will be no active Global Administrators and Privileged Role Administrators and administration of the tenant will effectively be locked, unless emergency access accounts are used.
+- Organization has unlicensed Global Administrators who need to receive admin Email Notifications. Only licensed Global Admininstrator accounts receive email notifications and using a mail-enabled break glass account to forward mail to unlicensed Global Administrors is the recommended solution.
 
 ## Create emergency access accounts
 
@@ -56,6 +57,13 @@ Create two or more emergency access accounts. These accounts should be cloud-onl
 1. [Monitor sign-in and audit logs](#monitor-sign-in-and-audit-logs).
 
 1. [Validate accounts regularly](#validate-accounts-regularly).
+
+## Forward Admin Email Notifications to administrators using PIM or with separate unlicensed global admin accounts
+1. Make the account a shared mailbox
+   
+1. Create a distribution group containing the licensed user account for users who use PIM or have seaprate unlicensed admin accounts
+   
+1. Forward mail from the breakglass account to the distribution group created in the step above
 
 ## Configuration requirements
 


### PR DESCRIPTION
As a partner I opened ticket 2502260010001012 back in February of this year. According to the response I received on that ticket today,

> The recommended approach to workaround [Accounts using PIM not receiving email] is to have enabled admin accounts for "Break Glass" scenarios, assign an email account and then forward all notifications to a DL. We have a well documented procedure to configure it and it will allow you to get the notifications:[Manage emergency access admin accounts - Microsoft Entra ID | Microsoft Learn](https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/security-emergency-access).
>  
> This is a similar approach to the one I believe you’re currently applying as per our last conversation.

Since this article doesn't even give a gist of how to do what they indicate is well documented, I propose the following changes so that supports assessment of this article is at least sort of correct. Feel free to improve upon this guidance. Creating step by step guidance on how to make the break glass account mail enabled and setup the forward is not a high priority to me considering support believes the article already has that information. Hopefully someone on your team is already working on this!

This is the article where I was expecting to find the guidance support says exists in this article.
https://learn.microsoft.com/en-us/microsoft-365/business-premium/m365bp-protect-admin-accounts?view=o365-worldwide#create-a-user-account-for-yourself

Hope this helps!
-jon