### PR TITLE
Update pim-how-to-activate-role.yml

### DIFF
--- a/docs/id-governance/privileged-identity-management/pim-how-to-activate-role.yml
+++ b/docs/id-governance/privileged-identity-management/pim-how-to-activate-role.yml
@@ -30,7 +30,8 @@ introduction: |
 
   >[!IMPORTANT]
   >If a user activating an administrative role is signed in to Microsoft Teams on a mobile device, they will receive a notification from the Teams app saying "Open Teams to continue receiving notifications for *&lt;email address&gt;*", or "*&lt;email address&gt;* needs to sign in to see notifications". The user will need to open the Teams app to continue receiving notifications. This behavior is by design.
-
+  >[!IMPORTANT]
+ >If your tenant has the 'Restrict access to Microsoft Entra Admin Center' Control set to 'Yes' identities that have Eligible assignments will not be able to access the Portal and Activate their PIM Roles. 
 procedureSection:
   - title: |
       Activate a role

--- a/docs/id-governance/privileged-identity-management/pim-how-to-activate-role.yml
+++ b/docs/id-governance/privileged-identity-management/pim-how-to-activate-role.yml
@@ -30,8 +30,10 @@ introduction: |
 
   >[!IMPORTANT]
   >If a user activating an administrative role is signed in to Microsoft Teams on a mobile device, they will receive a notification from the Teams app saying "Open Teams to continue receiving notifications for *&lt;email address&gt;*", or "*&lt;email address&gt;* needs to sign in to see notifications". The user will need to open the Teams app to continue receiving notifications. This behavior is by design.
+  
   >[!IMPORTANT]
- >If your tenant has the 'Restrict access to Microsoft Entra Admin Center' Control set to 'Yes' identities that have Eligible assignments will not be able to access the Portal and Activate their PIM Roles. 
+  >If your tenant has the 'Restrict access to Microsoft Entra Admin Center' Control set to 'Yes' identities that have Eligible assignments will not be able to access the Portal and Activate their PIM Roles.
+ 
 procedureSection:
   - title: |
       Activate a role


### PR DESCRIPTION
I have just encountered a customer who has this control enabled and the guidance does not match their experience. Therefore added a note that if customer are using the other control in Entra, then they won't be able to activate their PIM Roles as they have no assigned 'standing' roles