### PR TITLE
Updated script with corrected variables

### DIFF
--- a/docs/identity/users/licensing-powershell-graph-examples.md
+++ b/docs/identity/users/licensing-powershell-graph-examples.md
@@ -231,22 +231,9 @@ foreach ($group in $groups) {
     $groupId = $group.Id
     $groupName = $group.DisplayName
 
-    # Initialize counters for total members and members with license errors
-    $totalCount = 0
-    $licenseErrorCount = 0
-
-    # Get all members of the group that have license errors
-    $members = Get-MgGroupMemberWithLicenseError -GroupId $groupId
-
-    # Process each member
-    foreach ($member in $members) {
-        $totalCount++
-
-        # If the member has a license error (indicated by a non-empty Id), increment the error count
-        if (![string]::IsNullOrEmpty($member.Id)) {
-            $licenseErrorCount++
-        }
-    }
+    # Get count of the group's members and members with license errors
+    $totalCount = (Get-MgGroupMember -GroupId $GroupId -All).count
+    $licenseErrorCount = (Get-MgGroupMemberWithLicenseError -GroupId $groupId).count
 
     # Create a custom object with the group's information and counts
     $groupInfo += [PSCustomObject]@{


### PR DESCRIPTION
1. The variable $members on line 239 is only a count of members with errors and not the total member count of the group.
2. Iterating over each member of the $members variable and adding to the total count is redundant here as you need to obtain the full list/count of members initially.
3. The If statement to me does not make sense as the ID field should never return an empty value so you just need the total count without this statement.

Adding in a quick and easy count variable that essentially achieves the same result with less confusion.