### PR TITLE
fix: typo in npm install command

### DIFF
--- a/docs/identity-platform/tutorial-native-authentication-single-page-app-react-sign-up.md
+++ b/docs/identity-platform/tutorial-native-authentication-single-page-app-react-sign-up.md
@@ -40,7 +40,7 @@ In a location of choice in your computer, run the following commands to create a
   npx create-react-app reactspa --template typescript
   cd reactspa
   npm install ajv
-  npm installreact-router-dom
+  npm install react-router-dom
   npm install
   ```
 


### PR DESCRIPTION
Adding missing space between the npm install command and package name