### PR TITLE
Clarify CA policy enforcement for service principals in groups

### DIFF
--- a/docs/identity/conditional-access/workload-identity.md
+++ b/docs/identity/conditional-access/workload-identity.md
@@ -30,6 +30,9 @@ These differences make workload identities harder to manage and put them at high
 > [!NOTE]
 > Policy can be applied to single tenant service principals that are registered in your tenant. Third party SaaS and multi-tenanted apps are out of scope. Managed identities aren't covered by policy. Managed identities could be included in an [access review](../../id-governance/access-reviews-overview.md) instead.
 
+> [!NOTE]
+> While service principals can be added to groups, Conditional Access policies assigned to a group that contains a service principal are not enforced for that service principal. To enforce a Conditional Access policy for a service principal, it must be assigned directly to the policy as a workload identity.
+
 Conditional Access for workload identities enables blocking service principals:
 
 - From outside of known public IP ranges.


### PR DESCRIPTION
This pull request adds an important clarification to the "Conditional Access for workload identities" documentation.

It addresses a common scenario where administrators might add a service principal to a group and assume that any Conditional Access policies targeting that group will apply to the service principal. This is not the case.

This change adds a [!NOTE] to explicitly state that Conditional Access policies are not enforced on service principals through group membership. To be effective, the policy must be assigned directly to the service principal as a workload identity. This helps prevent misconfiguration and ensures administrators understand the correct procedure for securing workload identities.