### PR TITLE
Update how-to-prerequisites.md

### DIFF
--- a/docs/identity/hybrid/cloud-sync/how-to-prerequisites.md
+++ b/docs/identity/hybrid/cloud-sync/how-to-prerequisites.md
@@ -201,6 +201,9 @@ When using OU scoping filter
 
 - Nested OUs are supported (that is, you **can** sync an OU that has 130 nested OUs, but you **can't** sync 60 separate OUs in the same configuration).
 
+>[!NOTE]
+>At this time, it is not possible to check the scoping configuration size to determine if it is near to, reached or exceeded the 4 MB character limit which includes metadata. 
+
 ### Password Hash Sync
 
 - Using password hash sync with InetOrgPerson isn't supported.


### PR DESCRIPTION
I have added a note to inform users that it is not currently possible to check the configuration size, to determine, in larger environments, whether or not the configuration is close to or has exceeded the 4 MB size limit. 

I have included this after having a case open with Microsoft support for several months, trying to determine how to achieve this, with the official response coming back that its not currently possible.