### PR TITLE
Fix Powershell Cmdlet name in `How to use VM Tokens`

### DIFF
--- a/docs/identity/managed-identities-azure-resources/how-to-use-vm-token.md
+++ b/docs/identity/managed-identities-azure-resources/how-to-use-vm-token.md
@@ -301,8 +301,7 @@ $resource = 'https://management.azure.com'
 $response = Invoke-RestMethod -Method GET `
                             -Uri "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=$resource" `
                             -Headers @{ Metadata="true" }
-$content = $response.Content | ConvertFrom-Json
-$accessToken = $content.access_token
+$accessToken = $response.access_token
 Write-Host "Access token using a User-Assigned Managed Identity is $accessToken"
 
 # Use the access token to get resource information for the VM


### PR DESCRIPTION
The PowerShell cmdlet is called `Invoke-RestMethod`, not `Invoke-RestMeth` as mentioned in this doc. Fix the cmdlet name so future folks who try to run these commands don't run into issues.

The command also includes a Variable reference $Resource, but uses single quotes for the string so the variable isn't being substituted. Switch to double quotes so the strings behave as expected.

<img width="2781" height="733" alt="image" src="https://github.com/user-attachments/assets/bd53aee5-9eeb-4f09-b3f7-633e77c3122a" />
Screenshot above shows the original command failing on the first line. Second line shows the command failing again, this time with an error ' The resource principal named $resource was not found'. The third line shows the command running successfully with no output, and the fourth line shows the successful token acquisition.


After this step, we're instructed to do `$content = $response.Content | ConvertFrom-Json` to convert the result, but attempting to do so throws an error. The following step can fetch the access token without needing to manipulate the response, so bypass this step.
<img width="2689" height="217" alt="image" src="https://github.com/user-attachments/assets/5527ab07-bd10-41ad-b21b-91432f0da506" />
