### PR TITLE
Fix URL formatting in custom domain documentation

### DIFF
--- a/docs/identity/app-proxy/how-to-configure-custom-domain.md
+++ b/docs/identity/app-proxy/how-to-configure-custom-domain.md
@@ -15,7 +15,7 @@ ms.custom: sfi-image-nochange
 
 # Configure custom domains with Microsoft Entra application proxy
 
-When you publish an application through Microsoft Entra application proxy, you create an external URL for your users. This URL gets the default domain *`yourtenant.msappproxy.net`*. For example, if you publish an app named *Expenses* in your tenant named *Contoso*, the external URL is *`https:\//expenses-contoso.msappproxy.net`*. If you want to use your own domain name instead of *`msappproxy.net`*, you can configure a custom domain for your application. 
+When you publish an application through Microsoft Entra application proxy, you create an external URL for your users. This URL gets the default domain *`yourtenant.msappproxy.net`*. For example, if you publish an app named *Expenses* in your tenant named *Contoso*, the external URL is *`https://expenses-contoso.msappproxy.net`*. If you want to use your own domain name instead of *`msappproxy.net`*, you can configure a custom domain for your application. 
 
 ## Benefits of custom domains
 


### PR DESCRIPTION
This pull request makes a minor correction to the documentation for configuring custom domains with Microsoft Entra application proxy. The change fixes the formatting of an example URL by removing an unnecessary escape character.

* Documentation: Corrected the example external URL in `docs/identity/app-proxy/how-to-configure-custom-domain.md` by removing the backslash before the double slash, ensuring proper URL formatting.