### PR TITLE
Adding PIM for Auth context - Update concept-conditional-access-cloud-apps.md

### DIFF
--- a/docs/identity/conditional-access/concept-conditional-access-cloud-apps.md
+++ b/docs/identity/conditional-access/concept-conditional-access-cloud-apps.md
@@ -240,7 +240,7 @@ To learn more about using authentication contexts, see the following articles.
 - [Use sensitivity labels to protect content in Microsoft Teams, Microsoft 365 groups, and SharePoint sites](/purview/sensitivity-labels-teams-groups-sites)
 - [Microsoft Defender for Cloud Apps](/defender-cloud-apps/session-policy-aad?branch=pr-en-us-2082#require-step-up-authentication-authentication-context)
 - [Custom applications](~/identity-platform/developer-guide-conditional-access-authentication-context.md)
-- [Priviledged Identity Management - On activation, require Microsoft Entra Conditional Access authentication context](/entra/id-governance/privileged-identity-management/pim-resource-roles-configure-role-settings#on-activation-require-microsoft-entra-conditional-access-authentication-context)
+- [Privileged Identity Management - On activation, require Microsoft Entra Conditional Access authentication context](/entra/id-governance/privileged-identity-management/pim-resource-roles-configure-role-settings#on-activation-require-microsoft-entra-conditional-access-authentication-context)
 
 ## Related content
 


### PR DESCRIPTION
We must include the capability of using Authentication context for role elevation via PIM as the current version doesn't specify this anywhere. I had the chance to work on a case where customer was lost about this topic, since the doc was not covering it.