### PR TITLE
Update device-join-macos-platform-single-sign-on-kerberos-configurati…

### DIFF
--- a/docs/identity/devices/device-join-macos-platform-single-sign-on-kerberos-configuration.md
+++ b/docs/identity/devices/device-join-macos-platform-single-sign-on-kerberos-configuration.md
@@ -100,6 +100,8 @@ Use the following settings to configure the on-premises Active Directory profile
             <string>CONTOSO.COM</string>
             <key>PayloadDisplayName</key>
             <string>Single Sign-On Extensions Payload for On-Premises</string>
+            <key>PayloadIdentifier</key>
+            <string>com.apple.extensiblesso.1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5</string>
             <key>PayloadType</key>
             <string>com.apple.extensiblesso</string>
             <key>PayloadUUID</key>
@@ -179,6 +181,8 @@ Use the following settings to configure the Microsoft Entra ID Cloud Kerberos pr
             <string>KERBEROS.MICROSOFTONLINE.COM</string>
             <key>PayloadDisplayName</key>
             <string>Single Sign-On Extensions Payload for Microsoft Entra ID Cloud Kerberos</string>
+            <key>PayloadIdentifier</key>
+            <string>com.apple.extensiblesso.00aa00aa-bb11-cc22-dd33-44ee44ee44ee</string>
             <key>PayloadType</key>
             <string>com.apple.extensiblesso</string>
             <key>PayloadUUID</key>


### PR DESCRIPTION
…on.md

Example generates an error as Payload identifier is missing:

Error code -2016336218 / 0x87d126a6

This was introduced when the example was added by @mepples21  in commit 0d905b457e5910a447eb8aa1acb1ea6dc4042ec6