### PR TITLE
Improve clarity for disabling SSPR for admins

### DIFF
--- a/docs/identity/authentication/concept-sspr-policy.md
+++ b/docs/identity/authentication/concept-sspr-policy.md
@@ -115,7 +115,7 @@ A two-gate policy applies in the following circumstances:
 
 * Microsoft Entra Connect synchronizes identities from your on-premises directory
 
-You can disable the use of SSPR for administrator accounts by setting the value of the `AllowedToUseSspr` property on the tenant authorization policy to `false`. Policy changes to enable or disable SSPR for administrator accounts can take up to 60 minutes to take effect. To 
+You can disable the use of SSPR for administrator accounts by setting the value of the `AllowedToUseSspr` property on the tenant authorization policy to `false`. Policy changes to enable or disable SSPR for administrator accounts can take up to 60 minutes to take effect.
 
 # [PowerShell](#tab/ms-powershell)
 
@@ -136,6 +136,7 @@ PATCH https://graph.microsoft.com/v1.0/policies/authorizationPolicy
   "allowedToUseSSPR":false
 }
 ```
+---
 
 ### Exceptions
 

--- a/docs/identity/authentication/concept-sspr-policy.md
+++ b/docs/identity/authentication/concept-sspr-policy.md
@@ -115,7 +115,27 @@ A two-gate policy applies in the following circumstances:
 
 * Microsoft Entra Connect synchronizes identities from your on-premises directory
 
-You can disable the use of SSPR for administrator accounts using the [Update-MgPolicyAuthorizationPolicy](/powershell/module/microsoft.graph.identity.signins/update-mgpolicyauthorizationpolicy) PowerShell cmdlet. The `-AllowedToUseSspr:$true|$false` parameter enables/disables SSPR for administrators. Policy changes to enable or disable SSPR for administrator accounts can take up to 60 minutes to take effect. 
+You can disable the use of SSPR for administrator accounts by setting the value of the `AllowedToUseSspr` property on the tenant authorization policy to `false`. Policy changes to enable or disable SSPR for administrator accounts can take up to 60 minutes to take effect. To 
+
+# [PowerShell](#tab/ms-powershell)
+
+[Update-MgPolicyAuthorizationPolicy](/powershell/module/microsoft.graph.identity.signins/update-mgpolicyauthorizationpolicy)
+
+```powershell
+Connect-MgGraph -Scopes Policy.ReadWrite.Authorization
+Update-MgPolicyAuthorizationPolicy -AllowedToUseSspr:$false
+```
+
+# [Microsoft Graph](#tab/ms-graph)
+
+[Update authorizationPolicy](/graph/api/authorizationpolicy-update)
+
+```http
+PATCH https://graph.microsoft.com/v1.0/policies/authorizationPolicy
+{
+  "allowedToUseSSPR":false
+}
+```
 
 ### Exceptions
 


### PR DESCRIPTION
I would like to make this easier for others to understand. I often share this article and tell people to run the command, and they can't get it working because the scope hasn't been consented or they aren't quite sure how to run it. I think it's also helpful to provide the PATCH command for use with Graph Explorer / Invoke-MgGraphRequest.