### PR TITLE
Fix missing ** for bold

### DIFF
--- a/docs/identity/users/users-custom-security-attributes.md
+++ b/docs/identity/users/users-custom-security-attributes.md
@@ -31,7 +31,7 @@ To assign or remove custom security attributes for a user in your Microsoft Entr
 
 1. Make sure that you have defined custom security attributes. For more information, see [Add or deactivate custom security attribute definitions in Microsoft Entra ID](~/fundamentals/custom-security-attributes-add.md).
 
-1. Browse to **Identity **Users** > **All users**.
+1. Browse to **Identity** > **Users** > **All users**.
 
 1. Find and select the user you want to assign custom security attributes to.
 
@@ -57,7 +57,7 @@ To assign or remove custom security attributes for a user in your Microsoft Entr
 
 1. Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com) as an [Attribute Assignment Administrator](~/identity/role-based-access-control/permissions-reference.md#attribute-assignment-administrator).
 
-1. Browse to **Identity **Users** > **All users**.
+1. Browse to **Identity** > **Users** > **All users**.
 
 1. Find and select the user that has a custom security attribute assignment value you want to update.
 
@@ -77,7 +77,7 @@ You can filter the list of custom security attributes assigned to users on the A
 
 1. Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com) as an [Attribute Assignment Reader](~/identity/role-based-access-control/permissions-reference.md#attribute-assignment-reader).
 
-1. Browse to **Identity **Users** > **All users**.
+1. Browse to **Identity** > **Users** > **All users**.
 
 1. Select **Add filter** to open the Add filter pane.
 
@@ -97,7 +97,7 @@ You can filter the list of custom security attributes assigned to users on the A
 
 1. Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com) as an [Attribute Assignment Administrator](~/identity/role-based-access-control/permissions-reference.md#attribute-assignment-administrator).
 
-1. Browse to **Identity **Users** > **All users**.
+1. Browse to **Identity** > **Users** > **All users**.
 
 1. Find and select the user that has the custom security attribute assignments you want to remove.
 


### PR DESCRIPTION
Noticed we were missing the trailing ** for bold and > for navication on Identity. Added to make it look correct.