### PR TITLE
Update troubleshoot-primary-refresh-token.md

### DIFF
--- a/docs/identity/devices/troubleshoot-primary-refresh-token.md
+++ b/docs/identity/devices/troubleshoot-primary-refresh-token.md
@@ -409,7 +409,7 @@ Common general network-related issues.
 
 #### Regular logs
 
-1. Download the [Auth script archive](https://aka.ms/authscripts), and extract the scripts into a local directory. If it's necessary, review the usage instructions in [KB&nbsp;4487175](https://aka.ms/howto-authscripts).
+1. Download the [Auth script archive](https://aka.ms/authscripts), and extract the scripts into a local directory.
 1. Open an administrative PowerShell session, and change the current directory to the directory in which you saved the Auth scripts.
 1. To begin the error tracing session, enter the following command:
 


### PR DESCRIPTION
The removed line (If it's necessary, review the usage instructions in KB 4487175.) have a link pointing to a "https://aka.ms/howto-authscripts" that points to an internal link: "https://internal.evergreen.microsoft.com/en-us/topic/944d1348-83b9-87c0-7ef4-1d76b5c2e5f9"