### PR TITLE
Clarify installation prerequisites for Entra Connect

### DIFF
--- a/docs/identity/hybrid/connect/how-to-connect-install-prerequisites.md
+++ b/docs/identity/hybrid/connect/how-to-connect-install-prerequisites.md
@@ -58,7 +58,7 @@ To read more about securing your Active Directory environment, see [Best practic
 
 #### Installation prerequisites
 
-- Microsoft Entra Connect must be installed on a domain-joined Windows Server 2016 or later. We recommend using domain-joined Windows Server 2022. You can deploy Microsoft Entra Connect on Windows Server 2016. However, since Windows Server 2016 is in extended support, you might need [a paid support program](/lifecycle/policies/fixed#extended-support) if you require support for this configuration.
+- Microsoft Entra Connect must be installed on a domain-joined Windows Server 2016-2022. We recommend using domain-joined Windows Server 2022. Installing on Windows Server 2025 (which is not yet supported) may cause service failures or unexpected behavior. You can deploy Microsoft Entra Connect on Windows Server 2016. However, since Windows Server 2016 is in extended support, you might need [a paid support program](/lifecycle/policies/fixed#extended-support) if you require support for this configuration.
 - The minimum .NET Framework version required is 4.6.2, and newer versions of .NET are also supported.  .NET version 4.8 and greater offers the best accessibility compliance.
 - Microsoft Entra Connect can't be installed on Small Business Server or Windows Server Essentials before 2019 (Windows Server Essentials 2019 is supported). The server must be using Windows Server standard or better. 
 - The Microsoft Entra Connect server must have a full GUI installed. Installing Microsoft Entra Connect on Windows Server Core isn't supported. 


### PR DESCRIPTION
Updated installation prerequisites for Microsoft Entra Connect to specify supported Windows Server versions and warn against using unsupported versions.