### PR TITLE
Update provisioning agent docs: replace Microsoft Entra with Microsoft Azure AD

### DIFF
--- a/docs/global-secure-access/how-to-configure-connectors.md
+++ b/docs/global-secure-access/how-to-configure-connectors.md
@@ -53,7 +53,7 @@ The Microsoft Entra private network connector requires a server running Windows 
 > ```
 
 > [!WARNING]
-> If you've deployed Microsoft Entra Password Protection Proxy, do not install Microsoft Entra application proxy and Microsoft Entra Password Protection Proxy together on the same machine. Microsoft Entra application proxy and Microsoft Entra Password Protection Proxy install different versions of the Microsoft Entra Connect Agent Updater service. These different versions are incompatible when installed together on the same machine.
+> If you've deployed Microsoft Entra Password Protection Proxy, do not install Microsoft Entra application proxy and Microsoft Entra Password Protection Proxy together on the same machine. Microsoft Entra application proxy and Microsoft Entra Password Protection Proxy install different versions of the Microsoft Azure AD Connect Agent Updater service. These different versions are incompatible when installed together on the same machine.
 
 #### Transport Layer Security (TLS) requirements
 

--- a/docs/identity/app-provisioning/on-premises-application-provisioning-architecture.md
+++ b/docs/identity/app-provisioning/on-premises-application-provisioning-architecture.md
@@ -154,8 +154,8 @@ You can also check whether all the required ports are open.
  1. Sign in to the Windows server where the provisioning agent is installed.
  2. Go to **Control Panel** > **Uninstall or Change a Program**.
  3. Uninstall the following programs:
-  - Microsoft Entra Connect Provisioning Agent
-  - Microsoft Entra Connect Agent Updater
+  - Microsoft Azure AD Connect Provisioning Agent
+  - Microsoft Azure AD Connect Agent Updater
   - Microsoft Entra Connect Provisioning Agent Package
 
 ## Provisioning agent history

--- a/docs/identity/app-provisioning/on-premises-ecma-troubleshoot.md
+++ b/docs/identity/app-provisioning/on-premises-ecma-troubleshoot.md
@@ -19,7 +19,7 @@ After you configure the provisioning agent and the Extensible Connectivity(ECMA)
 
  1. Check that the agent and ECMA host are running:
      1. On the server with the agent installed, open **Services** by going to **Start** > **Run** > **Services.msc**.
-     2. Under **Services**, make sure the **Microsoft Entra Connect Provisioning Agent**, and **Microsoft ECMA2Host** services are present and their status is *Running*.
+     2. Under **Services**, make sure the **Microsoft Azure AD Connect Provisioning Agent**, and **Microsoft ECMA2Host** services are present and their status is *Running*.
     
         ![Screenshot that shows that the ECMA service is running.](./media/on-premises-ecma-troubleshoot/tshoot-1.png)
 
@@ -41,7 +41,7 @@ After you configure the provisioning agent and the Extensible Connectivity(ECMA)
  1. Ensure that you've assigned one or more agents to the application in the Azure portal.
  1. After you assign an agent, you need to wait 10 to 20 minutes for the registration to complete. The connectivity test won't work until the registration completes.
  1. Ensure that you're using a valid certificate that has not expired. Go to the **Settings** tab of the ECMA host to view the certificate expiration date. If the certificate has expired, click `Generate certificate` to generate a new certificate.
- 1. Restart the provisioning agent by going to the taskbar on your VM by searching for the Microsoft Entra Connect provisioning agent. Right-click **Stop**, and then select **Start**.
+ 1. Restart the provisioning agent by going to the taskbar on your VM by searching for the Microsoft Azure AD Connect Provisioning Agent. Right-click **Stop**, and then select **Start**.
  1. If you continue to see `The ECMA host is currently importing data from the target application` even after restarting the ECMA Connector Host and the provisioning agent, and waiting for the initial import to complete, then you may need to cancel and start over configuring provisioning to the application in the Azure portal.
 
  1. When you provide the tenant URL in the Azure portal, ensure that it follows the following pattern. You can replace `localhost` with your host name, but it isn't required. Replace `connectorName` with the name of the connector you specified in the ECMA host. The error message 'invalid resource' generally indicates that the URL does not follow the expected format.
@@ -211,7 +211,7 @@ You might experience the following error scenarios.
 
 You might receive an error message that states:
 
-"Service 'Microsoft Entra Connect Provisioning Agent' failed to start. Check that you have sufficient privileges to start the system services." 
+"Service 'Microsoft Azure AD Connect Provisioning Agent' failed to start. Check that you have sufficient privileges to start the system services." 
 
 This problem is typically caused by a group policy that prevented permissions from being applied to the local NT Service sign-in account created by the installer (NT SERVICE\AADConnectProvisioningAgent). These permissions are required to start the service.
 
@@ -219,7 +219,7 @@ To resolve this problem:
 
  1. Sign in to the server with an administrator account.
  2. Open **Services** by either navigating to it or by going to **Start** > **Run** > **Services.msc**.
- 3. Under **Services**, double-click **Microsoft Entra Connect Provisioning Agent**.
+ 3. Under **Services**, double-click **Microsoft Azure AD Connect Provisioning Agent**.
  4. On the **Log On** tab, change **This account** to a domain admin. Then restart the service. 
 
 This test verifies that your agents can communicate with Azure over port 443. Open a browser, and go to the previous URL from the server where the agent is installed.

--- a/docs/identity/app-provisioning/on-premises-ldap-connector-linux.md
+++ b/docs/identity/app-provisioning/on-premises-ldap-connector-linux.md
@@ -301,7 +301,7 @@ Follow these steps to confirm that the connector host is started and has identif
 
  3. Enter the **Secret Token** value that you defined when you created the connector.
      >[!NOTE]
-     >If you just assigned the agent to the application, please wait 10 minutes for the registration to complete. The connectivity test won't work until the registration completes. Forcing the agent registration to complete by restarting the provisioning agent on your server can speed up the registration process. Go to your server, search for **services** in the Windows search bar, identify the **Microsoft Entra Connect Provisioning Agent** service, right-select the service, and restart.
+     >If you just assigned the agent to the application, please wait 10 minutes for the registration to complete. The connectivity test won't work until the registration completes. Forcing the agent registration to complete by restarting the provisioning agent on your server can speed up the registration process. Go to your server, search for **services** in the Windows search bar, identify the **Microsoft Azure AD Connect Provisioning Agent** service, right-select the service, and restart.
  4. Select **Test Connection**, and wait one minute.
  5. After the connection test is successful and indicates that the supplied credentials are authorized to enable provisioning, select **Save**.</br>
      [![Screenshot that shows testing an agent.](~/includes/media/app-provisioning-sql/configure-9.png)](~/includes/media/app-provisioning-sql/configure-9.png#lightbox)
@@ -467,7 +467,7 @@ Now that your attributes are mapped and an initial user is assigned, you can tes
 
  1. On the server the running the Microsoft Entra ECMA Connector Host, select **Start**.
  2. Enter **run** and enter **services.msc** in the box.
- 3. In the **Services** list, ensure that both the **Microsoft Entra Connect Provisioning Agent** service and the **Microsoft ECMA2Host** services are running. If not, select **Start**.
+ 3. In the **Services** list, ensure that both the **Microsoft Azure AD Connect Provisioning Agent** service and the **Microsoft ECMA2Host** services are running. If not, select **Start**.
 
 
  1. In the Azure portal, select **Enterprise applications**.

--- a/docs/identity/app-provisioning/on-premises-powershell-connector.md
+++ b/docs/identity/app-provisioning/on-premises-powershell-connector.md
@@ -284,7 +284,7 @@ Follow these steps to confirm the connector host is started and has identified a
 1. Enter the **Secret Token** value that you defined when you created the connector.
 
    > [!NOTE]
-   > If you just assigned the agent to the application, please wait 10 minutes for the registration to complete. The connectivity test won't work until the registration completes. Forcing the agent registration to complete by restarting the provisioning agent on your server can speed up the registration process. Go to your server, search for **services** in the Windows search bar, identify the **Microsoft Entra Connect Provisioning Agent** service, right-select the service, and restart.
+   > If you just assigned the agent to the application, please wait 10 minutes for the registration to complete. The connectivity test won't work until the registration completes. Forcing the agent registration to complete by restarting the provisioning agent on your server can speed up the registration process. Go to your server, search for **services** in the Windows search bar, identify the **Microsoft Azure AD Connect Provisioning Agent** service, right-select the service, and restart.
 
 1. Select **Test Connection**, and wait one minute.
 1. After the connection test is successful and indicates that the supplied credentials are authorized to enable provisioning, select **Save**.
@@ -310,7 +310,7 @@ Return to the web browser window where you were configuring the application prov
 1. Enter the **Secret Token** value that you defined when you created the connector.
 
    > [!NOTE]
-   > If you just assigned the agent to the application, please wait 10 minutes for the registration to complete. The connectivity test won't work until the registration completes. Forcing the agent registration to complete by restarting the provisioning agent on your server can speed up the registration process. Go to your server, search for **services** in the Windows search bar, identify the **Microsoft Entra Connect Provisioning Agent Service**, right-select the service, and restart.
+   > If you just assigned the agent to the application, please wait 10 minutes for the registration to complete. The connectivity test won't work until the registration completes. Forcing the agent registration to complete by restarting the provisioning agent on your server can speed up the registration process. Go to your server, search for **services** in the Windows search bar, identify the **Microsoft Azure AD Connect Provisioning Agent Service**, right-select the service, and restart.
 
 1. Select **Test Connection**, and wait one minute.
 1. After the connection test is successful and indicates that the supplied credentials are authorized to enable provisioning, select **Save**.

--- a/docs/identity/app-provisioning/on-premises-web-services-connector.md
+++ b/docs/identity/app-provisioning/on-premises-web-services-connector.md
@@ -234,7 +234,7 @@ To connect the Microsoft Entra provisioning agent with your application, follow 
 
  5. Enter the **Secret Token** value that you defined when you created the connector.
      >[!NOTE]
-     >If you just assigned the agent to the application, please wait 10 minutes for the registration to complete. The connectivity test won't work until the registration completes. Forcing the agent registration to complete by restarting the provisioning agent on your server can speed up the registration process. Go to your server, search for **services** in the Windows search bar, identify the **Microsoft Entra Connect Provisioning Agent Service**, right-select the service, and restart.
+     >If you just assigned the agent to the application, please wait 10 minutes for the registration to complete. The connectivity test won't work until the registration completes. Forcing the agent registration to complete by restarting the provisioning agent on your server can speed up the registration process. Go to your server, search for **services** in the Windows search bar, identify the **Microsoft Azure AD Connect Provisioning Agent Service**, right-select the service, and restart.
  1. Select **Test Connection**, and wait one minute.
 
  1. After the connection test is successful and indicates that the supplied credentials are authorized to enable provisioning, select **Save**.

--- a/docs/identity/hybrid/cloud-sync/how-to-automatic-upgrade.md
+++ b/docs/identity/hybrid/cloud-sync/how-to-automatic-upgrade.md
@@ -32,8 +32,8 @@ To verify your version, right-click the executable and select properties and the
 ## Uninstall the agent
 To remove the agent, go to **Uninstall or change a program** and uninstall the following:
 
-- **Microsoft Entra Connect Agent Updater**
-- **Microsoft Entra Provisioning Agent**
+- **Microsoft Azure AD Connect Agent Updater**
+- **Microsoft Azure AD Connect Agent Provisioning Agent**
 - **Microsoft Entra Provisioning Agent Package**
 
 ![Agent removal](media/how-to-automatic-upgrade/agent-3.png)

--- a/docs/identity/hybrid/cloud-sync/how-to-troubleshoot.md
+++ b/docs/identity/hybrid/cloud-sync/how-to-troubleshoot.md
@@ -75,7 +75,7 @@ However, during the name resolution, the CNAME records might contain DNS records
 To verify that the agent is running, follow these steps:
 
 1. On the server with the agent installed, open **Services**. Do this by going to **Start** > **Run** > **Services.msc**.
-1. Under **Services**, make sure **Microsoft Entra Connect Agent Updater** and **Microsoft Entra Provisioning Agent** are there. Also confirm that their status is *Running*.
+1. Under **Services**, make sure **Microsoft Azure AD Connect Agent Updater** and **Microsoft Azure AD Connect Agent** are there. Also confirm that their status is *Running*.
 
    ![Screenshot of local services and their status.](media/how-to-troubleshoot/troubleshoot-1.png)
 
@@ -87,7 +87,7 @@ The following sections describe some common agent installation problems, and typ
 
 You might receive an error message that states:
 
-*Service 'Microsoft Entra Provisioning Agent' failed to start. Verify that you have sufficient privileges to start the system services.* 
+*Service 'Microsoft Azure AD Connect Agent' failed to start. Verify that you have sufficient privileges to start the system services.* 
 
 This problem is typically caused by a group policy. The policy prevented permissions from being applied to the local NT Service sign-in account created by the installer (`NT SERVICE\AADConnectProvisioningAgent`). These permissions are required to start the service.
 

--- a/docs/identity/hybrid/connect/how-to-connect-health-adfs.md
+++ b/docs/identity/hybrid/connect/how-to-connect-health-adfs.md
@@ -106,7 +106,7 @@ At this point, the agent services should start to automatically allow the agent 
 
 To verify that the agent was installed, look for the following services on the server. If you completed the configuration, they should already be running. Otherwise, they're stopped until the configuration is complete.
 
-- Microsoft Entra Connect Agent Updater
+- Microsoft Azure AD Connect Agent Updater
 - Microsoft Entra Connect Health Agent
 
 :::image type="content" source="media/how-to-connect-health-agent-install/install5.png" alt-text="Screenshot that shows Microsoft Entra Connect Health AD FS services.":::

--- a/docs/identity/hybrid/connect/how-to-connect-health-agent-install.md
+++ b/docs/identity/hybrid/connect/how-to-connect-health-agent-install.md
@@ -87,7 +87,7 @@ The Microsoft Entra Connect Health agent for sync is installed automatically in 
 
 To verify that the agent has been installed, look for the following services on the server. If you completed the configuration, the services should already be running. Otherwise, the services are stopped until the configuration is complete.
 
-- Microsoft Entra Connect Agent Updater
+- Microsoft Azure AD Connect Agent Updater
 - Microsoft Entra Connect Health Agent
 
 :::image type="content" source="media/how-to-connect-health-agent-install/install5.png" alt-text="Screenshot that shows the running Microsoft Entra Connect Health for sync services on the server.":::
@@ -137,7 +137,7 @@ At this point, the agent services should start to automatically allow the agent 
 
 To verify that the agent was installed, look for the following services on the server. If you completed the configuration, they should already be running. Otherwise, they're stopped until the configuration is complete.
 
-- Microsoft Entra Connect Agent Updater
+- Microsoft Azure AD Connect Agent Updater
 - Microsoft Entra Connect Health Agent
 
 :::image type="content" source="media/how-to-connect-health-agent-install/install5.png" alt-text="Screenshot that shows Microsoft Entra Connect Health AD DS services.":::

--- a/docs/identity/hybrid/connect/how-to-connect-pta-faq.yml
+++ b/docs/identity/hybrid/connect/how-to-connect-pta-faq.yml
@@ -142,7 +142,7 @@ sections:
       - question: |
           How do I remove a Pass-through Authentication Agent?
         answer: |
-          As long as a Pass-through Authentication Agent is running, it remains active and continually handles user sign-in requests. If you want to uninstall an Authentication Agent, go to **Control Panel -> Programs -> Programs and Features**. Uninstall both the **Microsoft Entra Connect Authentication Agent** and the **Microsoft Entra Connect Agent Updater** programs.
+          As long as a Pass-through Authentication Agent is running, it remains active and continually handles user sign-in requests. If you want to uninstall an Authentication Agent, go to **Control Panel -> Programs -> Programs and Features**. Uninstall both the **Microsoft Entra Connect Authentication Agent** and the **Microsoft Azure AD Connect Agent Updater** programs.
           
           If you check the Pass-through Authentication blade on the [Microsoft Entra admin center](https://entra.microsoft.com) as at least a [Hybrid Identity Administrator](~/identity/role-based-access-control/permissions-reference.md#hybrid-identity-administrator). You should see the Authentication Agent showing as **Inactive**. This is *expected*. The Authentication Agent is automatically dropped from the list after 10 days.
           

--- a/docs/includes/app-provisioning-ldap.md
+++ b/docs/includes/app-provisioning-ldap.md
@@ -336,7 +336,7 @@ Follow these steps to confirm that the connector host has started and has read a
 
  3. Enter the **Secret Token** value that you defined when you created the connector.
      >[!NOTE]
-     >If you just assigned the agent to the application, please wait 10 minutes for the registration to complete. The connectivity test won't work until the registration completes. Forcing the agent registration to complete by restarting the provisioning agent on your server can speed up the registration process. Go to your server, search for **services** in the Windows search bar, identify the **Microsoft Entra Connect Provisioning Agent** service, right-click the service, and restart.
+     >If you just assigned the agent to the application, please wait 10 minutes for the registration to complete. The connectivity test won't work until the registration completes. Forcing the agent registration to complete by restarting the provisioning agent on your server can speed up the registration process. Go to your server, search for **services** in the Windows search bar, identify the **Microsoft Azure AD Connect Provisioning Agent** service, right-click the service, and restart.
  4. Select **Test Connection**, and wait one minute.
  5. After the connection test is successful and indicates that the supplied credentials are authorized to enable provisioning, select **Save**.</br>
      [![Screenshot that shows testing an agent.](.\media\app-provisioning-sql\configure-9.png)](.\media\app-provisioning-sql\configure-9.png#lightbox)
@@ -494,7 +494,7 @@ Now that your attributes are mapped and an initial user is assigned, you can tes
  
  1. On the server the running the Microsoft Entra ECMA Connector Host, select **Start**.
  2. Enter **run** and enter **services.msc** in the box.
- 3. In the **Services** list, ensure that both the **Microsoft Entra Connect Provisioning Agent** service and the **Microsoft ECMA2Host** services are running. If not, select **Start**.
+ 3. In the **Services** list, ensure that both the **Microsoft Azure AD Connect Provisioning Agent** service and the **Microsoft ECMA2Host** services are running. If not, select **Start**.
 
 
  1. In the Azure portal, select **Enterprise applications**.

--- a/docs/includes/app-provisioning-sap.md
+++ b/docs/includes/app-provisioning-sap.md
@@ -229,7 +229,7 @@ To connect the Microsoft Entra provisioning agent with SAP ECC, follow these ste
 
  5. Enter the **Secret Token** value that you defined when you created the connector.
      >[!NOTE]
-     >If you just assigned the agent to the application, please wait 10 minutes for the registration to complete. The connectivity test won't work until the registration completes. Forcing the agent registration to complete by restarting the provisioning agent on your server can speed up the registration process. Go to your server, search for **services** in the Windows search bar, identify the **Microsoft Entra Connect Provisioning Agent Service**, right-click the service, and restart.
+     >If you just assigned the agent to the application, please wait 10 minutes for the registration to complete. The connectivity test won't work until the registration completes. Forcing the agent registration to complete by restarting the provisioning agent on your server can speed up the registration process. Go to your server, search for **services** in the Windows search bar, identify the **Microsoft Azure AD Connect Provisioning Agent Service**, right-click the service, and restart.
  1. Select **Test Connection**, and wait one minute.
 
  1. After the connection test is successful and indicates that the supplied credentials are authorized to enable provisioning, select **Save**.

--- a/docs/includes/app-provisioning-sql.md
+++ b/docs/includes/app-provisioning-sql.md
@@ -382,7 +382,7 @@ If you are connecting to a new database or one that is empty and has no users, t
 
  5. Enter the **Secret Token** value that you defined when you created the connector.
      >[!NOTE]
-     >If you just assigned the agent to the application, please wait 10 minutes for the registration to complete. The connectivity test won't work until the registration completes. Forcing the agent registration to complete by restarting the provisioning agent on your server can speed up the registration process. Go to your server, search for **services** in the Windows search bar, identify the **Microsoft Entra Connect Provisioning Agent Service**, right-click the service, and restart.
+     >If you just assigned the agent to the application, please wait 10 minutes for the registration to complete. The connectivity test won't work until the registration completes. Forcing the agent registration to complete by restarting the provisioning agent on your server can speed up the registration process. Go to your server, search for **services** in the Windows search bar, identify the **Microsoft Azure AD Connect Provisioning Agent Service**, right-click the service, and restart.
  7. Select **Test Connection**, and wait one minute.
 
      ![Screenshot that shows assigning an agent.](.\media\app-provisioning-sql\configure-5.png)

--- a/docs/includes/governance/governance-workday-to-active-directory.md
+++ b/docs/includes/governance/governance-workday-to-active-directory.md
@@ -500,7 +500,7 @@ Refer to [Microsoft Entra Connect Provisioning Agent: Version release history](~
 
 #### Does Microsoft automatically push Provisioning Agent updates?
 
-Yes, Microsoft automatically updates the provisioning agent if the  Windows service **Microsoft Entra Connect Agent Updater** is up and running.
+Yes, Microsoft automatically updates the provisioning agent if the  Windows service **Microsoft Azure AD Connect Agent Updater** is up and running.
 
 <a name='can-i-install-the-provisioning-agent-on-the-same-server-running-azure-ad-connect'></a>
 
@@ -570,8 +570,8 @@ Yes, one Provisioning Agent can be configured to handle multiple AD domains as l
 * Sign in to the Windows server where the Provisioning Agent is installed.
 * Go to **Control Panel** > **Uninstall or Change a Program** menu
 * Uninstall the following programs:
-  * Microsoft Entra Connect Provisioning Agent
-  * Microsoft Entra Connect Agent Updater
+  * Microsoft Azure AD Connect Provisioning Agent
+  * Microsoft Azure AD Connect Agent Updater
   * Microsoft Entra Connect Provisioning Agent Package
 
 ### Workday to AD attribute mapping and configuration questions
@@ -719,7 +719,7 @@ This section covers the following aspects of troubleshooting:
 
 ### Configure provisioning agent to emit Event Viewer logs
 1. Sign in to the Windows Server machine where the provisioning agent is deployed
-1. Stop the service **Microsoft Entra Connect Provisioning Agent**.
+1. Stop the service **Microsoft Azure AD Connect Provisioning Agent**.
 1. Create a copy of the original config file: *C:\Program Files\Microsoft Azure AD Connect Provisioning Agent\AADConnectProvisioningAgent.exe.config*.
 1. Replace the existing `<system.diagnostics>` section with the following. 
    * The listener config **etw** emits messages to the EventViewer logs
@@ -746,14 +746,14 @@ This section covers the following aspects of troubleshooting:
      </system.diagnostics>
 
    ```
-1. Start the service **Microsoft Entra Connect Provisioning Agent**.
+1. Start the service **Microsoft Azure AD Connect Provisioning Agent**.
 
 ### Setting up Windows Event Viewer for agent troubleshooting
 
 1. Sign in to the Windows Server machine where the Provisioning Agent is deployed
 1. Open **Windows Server Event Viewer** desktop app.
 1. Select **Windows Logs > Application**.
-1. Use the **Filter Current Log…** option to view all events logged under the source **Microsoft Entra Connect Provisioning Agent** and exclude events with Event ID "5", by specifying the filter "-5" as shown below.
+1. Use the **Filter Current Log…** option to view all events logged under the source **Microsoft Azure AD Connect Provisioning Agent** and exclude events with Event ID "5", by specifying the filter "-5" as shown below.
    > [!NOTE]
    > Event ID 5 captures agent bootstrap messages to the Microsoft Entra cloud service and hence we filter it while analyzing the log files. 
 
@@ -873,8 +873,8 @@ This section covers commonly seen errors with Workday user provisioning and how 
 
 |#|Error Scenario |Probable Causes|Recommended Resolution|
 |--|---|---|---|
-|1.| Error installing the provisioning agent with error message:  *Service 'Microsoft Entra Connect Provisioning Agent' (AADConnectProvisioningAgent) failed to start. Verify that you have sufficient privileges to start the system.* | This error usually shows up if you're trying to install the provisioning agent on a domain controller and group policy prevents the service from starting.  it's also seen if you have a previous version of the agent running and  you haven't uninstalled it before starting a new installation.| Install the provisioning agent on a non-DC server. Ensure that previous versions of the agent are uninstalled before installing the new agent.|
-|2.| The Windows Service 'Microsoft Entra Connect Provisioning Agent' is in *Starting* state and doesn't switch to *Running* state. | As part of the installation, the agent wizard creates a local account (**NT Service\\AADConnectProvisioningAgent**) on the server and this is the logon account used for starting the service. If a security policy on your Windows server prevents local accounts from running the services, you'll encounter this error. | Open the *Services console*. Right click on the Windows Service 'Microsoft Entra Connect Provisioning Agent' and in the logon tab specify the account of a domain administrator to run the service. Restart the service. |
+|1.| Error installing the provisioning agent with error message:  *Service 'Microsoft Azure AD Connect Provisioning Agent' (AADConnectProvisioningAgent) failed to start. Verify that you have sufficient privileges to start the system.* | This error usually shows up if you're trying to install the provisioning agent on a domain controller and group policy prevents the service from starting.  it's also seen if you have a previous version of the agent running and  you haven't uninstalled it before starting a new installation.| Install the provisioning agent on a non-DC server. Ensure that previous versions of the agent are uninstalled before installing the new agent.|
+|2.| The Windows Service 'Microsoft Azure AD Connect Provisioning Agent' is in *Starting* state and doesn't switch to *Running* state. | As part of the installation, the agent wizard creates a local account (**NT Service\\AADConnectProvisioningAgent**) on the server and this is the logon account used for starting the service. If a security policy on your Windows server prevents local accounts from running the services, you'll encounter this error. | Open the *Services console*. Right click on the Windows Service 'Microsoft Azure AD Connect Provisioning Agent' and in the logon tab specify the account of a domain administrator to run the service. Restart the service. |
 |3.| When configuring the provisioning agent with your AD domain in the step *Connect Active Directory*, the wizard takes a long time trying to load the AD schema and eventually times out. | This error usually shows up if the wizard is unable to contact the AD domain controller server due to firewall issues. | On the *Connect Active Directory* wizard screen, while providing the credentials for your AD domain, there's an option called *Select domain controller priority*. Use this option to select a domain controller that is in the same site as the agent server and ensure that there are no firewall rules blocking the communication. |
 
 #### Connectivity errors


### PR DESCRIPTION
This PR updates the provisioning agent documentation to explain that, although Microsoft Entra is the new name, some service names, application names and Event Viewer entries still display Microsoft Azure AD because those components have not yet been renamed.