### PR TITLE
Update custom-security-attributes-overview.md

### DIFF
--- a/docs/fundamentals/custom-security-attributes-overview.md
+++ b/docs/fundamentals/custom-security-attributes-overview.md
@@ -37,7 +37,7 @@ Custom security attributes **aren't** supported in the following areas:
 
 - [Microsoft Entra Domain Services](/entra/identity/domain-services/overview)
 - [Security Assertion Markup Language (SAML) token claims](~/identity-platform/saml-claims-customization.md)
-- [JSON Web Token claims](https://learn.microsoft.com/en-us/entra/identity-platform/security-tokens)
+- [JSON Web Token claims](/entra/identity-platform/security-tokens)
 
 ## Features of custom security attributes
 


### PR DESCRIPTION
Custom Security Attributes cannot be passed in JWTs issued from OAuth flows. This needs to be mentioned in our public docs.