### PR TITLE
Revise bulk download instructions for groups

### DIFF
--- a/docs/identity/users/groups-bulk-download.md
+++ b/docs/identity/users/groups-bulk-download.md
@@ -18,26 +18,36 @@ You can download a list of all the groups in your organization to a comma-separa
 
 ## Download a list of groups
 
+To download all groups in your organization:
 
-The columns downloaded are predefined.
+1. Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/GroupsManagementMenuBlade) and in the left-hand navigation pane, select the **Groups** tab and then **All groups**.
 
-1. Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com) as at least a [Groups Administrator](~/identity/role-based-access-control/permissions-reference.md#groups-administrator).
-1. Select **Microsoft Entra ID**.
-1. Select **Groups** > **All groups** > **Download groups**.
+    :::image type="content" source="Media/bulk-operations/groups-management-page.png" alt-text="Screenshot of the Microsoft Entra admin center Groups blade showing the All groups list with column headers and actions.":::
 
-      :::image type="content" source="./media/groups-bulk-download/download-groups.png" alt-text="Screenshot of the All groups page with Download groups selected.":::
+2. Select **Download groups**. The columns are predefined.
 
-1. On the **Groups download** page, select **Start** to receive a CSV file that lists your groups.
+    :::image type="content" source="Media/bulk-operations/download-groups-button.png" alt-text="Screenshot of the Groups page with the Download groups button highlighted in the toolbar.":::
 
-   :::image type="content" source="./media/groups-bulk-download/bulk-download.png" alt-text="Screenshot that shows the Download groups command is on the All groups page.":::
+3. Enter a filename and select **Start bulk operation**.
 
-If you experience errors, you can download and view the results file on the **Bulk operation results** page. The file contains the reason for each error. The file submission must match the provided template and include the exact column names. For more information about bulk operations limitations, see [Bulk download service limits](#bulk-download-service-limits).
+    :::image type="content" source="Media/bulk-operations/download-filename-dialog.png" alt-text="Screenshot of the Download groups dialog prompting for a filename before starting the bulk operation.":::
+
+4. Select the **Click here to view the status of each operation** link to navigate to the **Bulk operations** blade. 
+
+    :::image type="content" source="Media/bulk-operations/success-notification.png" alt-text="Screenshot of a success notification confirming the bulk groups download was submitted with a link to view status.":::
 
 ## Check download status
 
-You can see the status of all your pending bulk requests on the **Bulk operation results** page.
+Select the filename to download the CSV file containing all groups with the specified columns.
 
-:::image type="content" source="./media/groups-bulk-download/bulk-center.png" alt-text="Screenshot that shows the Check status option on the Bulk operation results page." lightbox="./media/groups-bulk-download/bulk-center.png":::
+    :::image type="content" source="Media/bulk-operations/success-notification.png" alt-text="Screenshot of a success notification confirming the bulk groups download was submitted with a link to view status.":::
+
+If you experience errors, you can download and view the results file on the **Bulk operations** blade. The file contains the reason for each error. The file submission must match the provided template and include the exact column names. For more information about bulk operations limitations, see [Bulk download service limits](#bulk-download-service-limits).
+
+> [!NOTE] 
+> The new bulk operations service does not support localization for templates.
+
+For information about limitations and to learn more about the previous Bulk Operations experience, see [Bulk operations service limitations](bulk-operations-service-limitations.md).
 
 ## Bulk download service limits
 


### PR DESCRIPTION
Updated the instructions for downloading group lists, added image references, and clarified error handling. NEED IMAGES from https://learn.microsoft.com/en-us/entra/fundamentals/bulk-operations#bulk-download-groups to be copied over.