### PR TITLE
Fix typo in PowerShell command for app ID tagging

### DIFF
--- a/docs/external-id/tenant-restrictions-v2.md
+++ b/docs/external-id/tenant-restrictions-v2.md
@@ -448,7 +448,7 @@ For more information, see [Creating your App Control AppId tagging policies](/wi
 After you create your policy in the wizard, or create your own by using PowerShell, convert the .xml output to an app ID tagging policy. The tagging policy marks the apps for which you want to allow access to Microsoft resources. The GUID output is your new policy ID.
 
 ```powershell
-   Set-CIPolicyIdInfo -ResetPolicyID .\policy.xml -AppIdTaggingPolicy -AppIdTaggingKey "M365ResourceAccessEnforced" -AppIdTaggingValue "True" 
+   Set-CIPolicyIdInfo -ResetPolicyID .\policy.xml -AppIdTaggingPolicy -AppIdTaggingKey "M365ResourceAccessEnforcement" -AppIdTaggingValue "True" 
 ```
 
 #### Step 3: Compile and deploy the policy for testing


### PR DESCRIPTION
Incorrect AppID tag name is provided in the example script - documentation states M365ResourceAccessEnforce**d** but it should be M365ResourceAccessEnforce**ment** to align with WCF filters