### PR TITLE
Import Microsoft.Graph.Identity.SignIns Module

### DIFF
--- a/docs/external-id/bulk-invite-powershell.md
+++ b/docs/external-id/bulk-invite-powershell.md
@@ -90,6 +90,8 @@ When prompted, enter your credentials.
 To send the invitations, run the following PowerShell script (where * * *c:\bulkinvite\invitations.csv* is the path of the CSV file):
 
 ```powershell
+Import-Module Microsoft.Graph.Identity.SignIns
+
 $invitations = import-csv c:\bulkinvite\invitations.csv
 
 $messageInfo = New-Object Microsoft.Graph.PowerShell.Models.MicrosoftGraphInvitedUserMessageInfo


### PR DESCRIPTION
The Microsoft.Graph.Identity.SignIns module must be imported to be able to create the $messageInfo object. Without the import, the script fails with ```New-Object: Cannot find type [Microsoft.Graph.PowerShell.Models.MicrosoftGraphInvitedUserMessageInfo]: verify that the assembly containing this type is loaded.```