### PR TITLE
G Suite provisioning configuration must be done from the Azure Portal

### DIFF
--- a/docs/identity/saas-apps/g-suite-provisioning-tutorial.md
+++ b/docs/identity/saas-apps/g-suite-provisioning-tutorial.md
@@ -106,7 +106,7 @@ This section guides you through the steps to configure the Microsoft Entra provi
 
 ### To configure automatic user provisioning for G Suite in Microsoft Entra ID:
 
-1. Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com) as at least a [Cloud Application Administrator](~/identity/role-based-access-control/permissions-reference.md#cloud-application-administrator).
+1. Sign in to the [Azure Portal](https://portal.azure.com/) as at least a [Cloud Application Administrator](~/identity/role-based-access-control/permissions-reference.md#cloud-application-administrator).
 1. Browse to **Entra ID** > **Enterprise apps**.
 
 	![Enterprise applications blade](./media/g-suite-provisioning-tutorial/enterprise-applications.png)


### PR DESCRIPTION
Based on my testing in my environment, provisioning with G Suite cannot be configured on 'entra.microsoft.com'. User must use azure.portal.com.