### PR TITLE
Update credential prompts for clarity on roles

### DIFF
--- a/docs/identity/authentication/howto-authentication-passwordless-security-key-on-premises.md
+++ b/docs/identity/authentication/howto-authentication-passwordless-security-key-on-premises.md
@@ -138,8 +138,8 @@ _(Example: For US Government Cloud)_
    # Kerberos Server object will be created in this Active Directory domain.
    $domain = $env:USERDNSDOMAIN
 
-   # Enter an Azure Active Directory Hybrid Identity Administrator username and password.
-   $cloudCred = Get-Credential -Message 'An Active Directory user who is a member of the Hybrid Identity Administrators group for Microsoft Entra ID.'
+   # Enter the username and password of an Entra ID user who is assigned the Hybrid Identity Administrator role.
+   $cloudCred = Get-Credential -Message 'A Microsoft Entra ID user who is assigned the Hybrid Identity Administrator role.'
 
    # Enter a Domain Administrator username and password.
    $domainCred = Get-Credential -Message 'An Active Directory user who is a member of the Domain Admins group and an Enterprise Admin for the forest.'


### PR DESCRIPTION
Parameter description for: Get-Credential -Message (CloudCredential parameter of Set-AzureADKerberosServer)

# Issue

The documentation currently states:
“An Active Directory user who is a member of the Hybrid Identity Administrators group for Microsoft Entra ID.”

This wording is inaccurate and misleading. Hybrid Identity Administrator is a Microsoft Entra ID role, not an on‑premises Active Directory group. The CloudCredential used with Set-AzureADKerberosServer must represent a Microsoft Entra ID account, and its permissions are evaluated in the cloud, not through AD DS group membership.

# Recommended Correction

Replace the sentence with the following:
“A Microsoft Entra ID user who is assigned the Hybrid Identity Administrator role.”

# Rationale

The CloudCredential parameter requires authentication to Microsoft Entra ID endpoints, which means the credential must be an Entra ID identity, not an AD DS account (even if the user happens to also exist on-prem). Role assignment for Hybrid Identity Administrator occurs in Entra ID, not in on‑prem Active Directory. This wording aligns with how permissions for Entra Kerberos server object creation are actually evaluated.