### PR TITLE
Add hybrid identity administrator as a possible role for config change

### DIFF
--- a/docs/identity/hybrid/connect/migrate-from-federation-to-cloud-authentication.md
+++ b/docs/identity/hybrid/connect/migrate-from-federation-to-cloud-authentication.md
@@ -237,7 +237,7 @@ To choose one of these options, you must know what your current settings are.
    
     ![View Additional tasks](media/deploy-cloud-user-authentication/additional-tasks.png)
 
-3. On the **Connect to Microsoft Entra ID** page, enter your Global Administrator account credentials.
+3. On the **Connect to Microsoft Entra ID** page, enter your Global Administrator or Hybrid Identity Administrator account credentials.
 
 4. On the **User sign-in** page:
 
@@ -338,7 +338,7 @@ On your Microsoft Entra Connect server, follow the steps 1- 5 in [Option A](#opt
 
 **Complete the conversion by using the Microsoft Graph PowerShell SDK:**
 
-1. In PowerShell, sign in to Microsoft Entra ID by using a Global Administrator account.
+1. In PowerShell, sign in to Microsoft Entra ID by using a Global Administrator or Hybrid Identity Administrator account.
    ```powershell
     Connect-MGGraph -Scopes "Domain.ReadWrite.All", "Directory.AccessAsUser.All"
     ```


### PR DESCRIPTION
Adding Hybrid Identity Administrator as a valid role that can achieve the same prerequisite as Global Admin.

[Entra Role - Hybrid Identity Administrator ](https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference#hybrid-identity-administrator)

