### PR TITLE
Mention External ID Self Service Sign Up

### DIFF
--- a/docs/identity/users/directory-self-service-signup.md
+++ b/docs/identity/users/directory-self-service-signup.md
@@ -8,7 +8,7 @@ ms.custom: sfi-ga-nochange
 ---
 # What is self-service sign-up for Microsoft Entra ID?
 
-This article explains how to use self-service sign-up to populate an organization in Microsoft Entra ID, part of Microsoft Entra. If you want to take over a domain name from an unmanaged Microsoft Entra organization, see [Take over an unmanaged tenant as administrator](domains-admin-takeover.md). If you want to offer self-service sign-up for guests or customers see [Self-service sign-up from Entra External ID](../../external-id/self-service-sign-up-overview.md).
+This article explains how to use self-service sign-up to populate an organization in Microsoft Entra ID, part of Microsoft Entra. If you want to take over a domain name from an unmanaged Microsoft Entra organization, see [Take over an unmanaged tenant as administrator](domains-admin-takeover.md). If you want to offer self-service sign-up for guests or customers see [Self-service sign-up from Microsoft Entra External ID](../../external-id/self-service-sign-up-overview.md).
 
 ## Why use self-service sign-up?
 

--- a/docs/identity/users/directory-self-service-signup.md
+++ b/docs/identity/users/directory-self-service-signup.md
@@ -8,7 +8,7 @@ ms.custom: sfi-ga-nochange
 ---
 # What is self-service sign-up for Microsoft Entra ID?
 
-This article explains how to use self-service sign-up to populate an organization in Microsoft Entra ID, part of Microsoft Entra. If you want to take over a domain name from an unmanaged Microsoft Entra organization, see [Take over an unmanaged tenant as administrator](domains-admin-takeover.md).
+This article explains how to use self-service sign-up to populate an organization in Microsoft Entra ID, part of Microsoft Entra. If you want to take over a domain name from an unmanaged Microsoft Entra organization, see [Take over an unmanaged tenant as administrator](domains-admin-takeover.md). If you want to offer self-service sign-up for guests or customers see [Self-service sign-up from Entra External ID](../../external-id/self-service-sign-up-overview.md).
 
 ## Why use self-service sign-up?
 


### PR DESCRIPTION
Currently this documentation page about Self-service Sign-up fails to even mention that there is a second self-service sign-up feature within Entra, namely the one that is part of Entra External ID. So I've added a mention of this at the top.

It may be that an even more comprehensive update is warranted to better clarify this and how the two don't even really interact don't interact, but this at a minimum might help people find documentation for other Self-Service Sign-Up scenarios within the overall Entra product.