### PR TITLE
Revise maximum token lifetime to 23 hours, 59 minutes, 59 seconds

### DIFF
--- a/docs/identity-platform/configurable-token-lifetimes.md
+++ b/docs/identity-platform/configurable-token-lifetimes.md
@@ -89,7 +89,7 @@ Access, ID, and SAML2 token configuration are affected by the following properti
     - Access tokens: varies, depending on the client application requesting the token. For example, continuous access evaluation (CAE) capable clients that negotiate CAE-aware sessions will see a long lived token lifetime (up to 28 hours).
     - ID tokens, SAML2 tokens: One hour
 - **Minimum**: 10 minutes
-- **Maximum**: One day
+- **Maximum**: 23 hours, 59 minutes, and 59 seconds
 
 ### Refresh and session token lifetime policy properties
 
@@ -103,7 +103,7 @@ Refresh and session token configuration are affected by the following properties
 |Single-Factor Session Token Max Age  |MaxAgeSessionSingleFactor |Session tokens (persistent and non-persistent)  |Until-revoked |
 |Multi-Factor Session Token Max Age  |MaxAgeSessionMultiFactor  |Session tokens (persistent and non-persistent)  |Until-revoked |
 
-Non-persistent session tokens have a Max Inactive Time of 24 hours whereas persistent session tokens have a Max Inactive Time of 90 days. Anytime the SSO session token is used within its validity period, the validity period is extended another 24 hours or 90 days. If the SSO session token isn't used within its Max Inactive Time period, it's considered expired and are no longer accepted. Any changes to this default period should be changed using [Conditional Access](~/identity/conditional-access/howto-conditional-access-session-lifetime.md).
+Non-persistent session tokens have a Max Inactive Time of 23 hours, 59 minutes, and 59 seconds whereas persistent session tokens have a Max Inactive Time of 90 days. Anytime the SSO session token is used within its validity period, the validity period is extended another 24 hours or 90 days. If the SSO session token isn't used within its Max Inactive Time period, it's considered expired and are no longer accepted. Any changes to this default period should be changed using [Conditional Access](~/identity/conditional-access/howto-conditional-access-session-lifetime.md).
 
 You can use PowerShell to find the policies that will be affected by the retirement.  Use the [PowerShell cmdlets](configure-token-lifetimes.yml) to see the all policies created in your organization, or to find which apps are linked to a specific policy.
 


### PR DESCRIPTION
Creating a tokenLifetimePolicy using Microsoft Graph fails with a 400 Property definition has an invalid value error when AccessTokenLifetime is set to "24:00:00", even though this documentation stated that access token lifetime can be configured “up to 24 hours” and includes examples implying this value is valid.
The policy is only accepted when the value is set to less than 24 hours (e.g. "23:59:59"). This PR updates the docs to reflect this previously undocumented constraint.