### PR TITLE
Clarify ADSync service account password change process

### DIFF
--- a/docs/identity/hybrid/connect/how-to-connect-sync-change-serviceacct-pass.md
+++ b/docs/identity/hybrid/connect/how-to-connect-sync-change-serviceacct-pass.md
@@ -10,26 +10,26 @@ ms.subservice: hybrid-connect
 ms.custom: sfi-ga-nochange, sfi-image-nochange
 ---
 # Changing the ADSync service account password
-If you change the ADSync service account password, the Synchronization Service doesn't start correctly until you abandon the encryption key and reinitialized the ADSync service account password. 
+Changing the ADSync service account password can prevent the Synchronization Service from starting successfully. When this occurs, the encryption key must be discarded and re-created, and the passwords for both the AD Connector account and the Microsoft Entra ID Connect account must be re-condfigured. 
 
 >[!IMPORTANT]
 > If you use Connect with a build from 2017 March or earlier, then you should not reset the password on the service account since Windows destroys the encryption keys for security reasons. You can't change the account to any other account without reinstalling Microsoft Entra Connect. If you upgrade to a build from 2017 April or later, then it is supported to change the password on the service account, but you can't change the account used. 
 
-Microsoft Entra Connect, as part of the Synchronization Services uses an encryption key to store the passwords of the AD DS Connector account and ADSync service account.  These accounts are encrypted before they're stored in the database. 
+Microsoft Entra Connect, as part of the Synchronization Services uses an encryption key to store the passwords of the AD DS Connector account and Entra ID Connector  account. These accounts are encrypted before they're stored in the database. 
 
 The encryption key used is secured using [Windows Data Protection (DPAPI)](/previous-versions/ms995355(v=msdn.10)). DPAPI protects the encryption key using the **ADSync service account**. 
 
-If you need to change the service account password you can use the procedures in [Abandoning the ADSync service account encryption key](#abandoning-the-adsync-service-account-encryption-key) to accomplish this.  These procedures should also be used if you need to abandon the encryption key for any reason.
+If you need to change the ADSync service account password you can use the procedures in [Abandoning the ADSync service account encryption key](#abandoning-the-adsync-service-account-encryption-key) to accomplish this.  These procedures should also be used if you need to abandon the encryption key for any reason.
 
 ## Issues that arise from changing the password
-There are two things that need to be done when you change the service account password.
+There are two things that need to be done when you change the ADSync service account password.
 
 First, you need to change the password under the Windows Service Control Manager.  Until this issue is resolved, you see the following issues:
 
 - If you try to start the Synchronization Service in Windows Service Control Manager, you receive the error "**Windows could not start the Microsoft Entra ID Sync service on Local Computer**". **Error 1069: The service did not start due to a logon failure.**"
 - Under Windows Event Viewer, the system event log contains an error with **Event ID 7038** and message “**The ADSync service was unable to log on as with the currently configured password due to the following error: The user name or password is incorrect.**"
 
-Second, under specific conditions, if the password is updated, the Synchronization Service can no longer retrieve the encryption key via DPAPI. Without the encryption key, the Synchronization Service can't decrypt the passwords required to synchronize to/from on-premises AD and Microsoft Entra ID.
+Second, under specific conditions, if the ADSync service account password is updated, the Synchronization Service can no longer retrieve the encryption key via DPAPI. Without the encryption key, the Synchronization Service can't decrypt the passwords required to synchronize to/from on-premises AD and Microsoft Entra ID.
 You see errors such as:
 
 - Under Windows Service Control Manager, if you try to start the Synchronization Service and it can't retrieve the encryption key, it fails with error “<strong>Windows could not start the Microsoft Entra ID Sync on Local Computer. For more information, review the System Event log. If this is a non-Microsoft service, contact the service vendor, and refer to service-specific error code -21451857952</strong>.”
@@ -53,7 +53,7 @@ If you need to abandon the encryption key, use the following procedures to accom
 
 2. [Provide the password of the AD DS Connector account](#provide-the-password-of-the-ad-ds-connector-account)
 
-3. [Reinitialize the password of the ADSync service account](#reinitialize-the-password-of-the-entra-id-connector-account)
+3. [Reinitialize the password of the Entra Id Connector account](#reinitialize-the-password-of-the-entra-id-connector-account)
 
 4. [Start the Synchronization Service](#start-the-synchronization-service)
 
@@ -86,24 +86,24 @@ As the existing passwords stored inside the database can no longer be decrypted,
 3. Select the **AD Connector** that corresponds to your on-premises AD. If you have more than one AD connector, repeat the following steps for each of them.
 4. Under **Actions**, select **Properties**.
 5. In the pop-up dialog, select **Connect to Active Directory Forest**:
-6. Enter the password of the AD DS account in the **Password** textbox. If you don't know its password, you must set it to a known value before performing this step.
+6. Enter the password of the AD DS connector account in the **Password** textbox. If you don't know its password, you must set it to a known value before performing this step.
 1. Click **OK** to save the new password and close the pop-up dialog.
 ![Screenshot that shows the "Connect to Active Directory Forest" page in the "Properties" window.](./media/how-to-connect-sync-change-serviceacct-pass/key6.png)
 
 #### Reinitialize the password of the Entra ID Connector account
 
-You can't directly provide the password of the Microsoft Entra service account to the Synchronization Service. Instead, you need to use the cmdlet **Add-ADSyncAADServiceAccount** to reinitialize the Microsoft Entra service account. The cmdlet resets the account password and makes it available to the Synchronization Service:
+You can't directly provide the password of the Microsoft Entra Id connector account to the Synchronization Service. Instead, you need to use the cmdlet **Add-ADSyncAADServiceAccount** to reinitialize the Microsoft Entra Id Connector account. The cmdlet resets the account password and makes it available to the Synchronization Service:
 
 1. Sign in to the Microsoft Entra Connect Sync server and open PowerShell.
-2. To provide the Microsoft Entra Global Administrator credentials, run `$credential = Get-Credential`.
+2. To provide the Microsoft Entra Id Global Administrator credentials, run `$credential = Get-Credential`.
 3. Run the cmdlet `Add-ADSyncAADServiceAccount -AADCredential $credential`.
  
    If the cmdlet is successful, the PowerShell command prompt appears. 
    
-The cmdlet resets the password for the service account and updates it both in Microsoft Entra ID and the sync engine.
+The cmdlet resets the password for the Entra Id Connector account and updates it in Microsoft Entra ID and the Synchronization Service.
 
 
-#### Start the Synchronization Service
+#### Re-Start the Synchronization Service
 Now that the Synchronization Service has access to the encryption key and all the passwords it needs, you can restart the service in the Windows Service Control Manager:
 
 

--- a/docs/identity/hybrid/connect/how-to-connect-sync-change-serviceacct-pass.md
+++ b/docs/identity/hybrid/connect/how-to-connect-sync-change-serviceacct-pass.md
@@ -51,20 +51,24 @@ If you need to abandon the encryption key, use the following procedures to accom
 
 1. [Abandon the existing encryption key](#abandon-the-existing-encryption-key)
 
-2. [Provide the password of the AD DS Connector account](#provide-the-password-of-the-ad-ds-connector-account)
+3. [Start the Synchronization Service](#start-the-synchronization-service)
+   
+4. [Provide the password of the AD DS Connector account](#provide-the-password-of-the-ad-ds-connector-account)
 
-3. [Reinitialize the password of the Entra Id Connector account](#reinitialize-the-password-of-the-entra-id-connector-account)
+5. [Reinitialize the password of the Entra Id Connector account](#reinitialize-the-password-of-the-entra-id-connector-account)
 
-4. [Start the Synchronization Service](#start-the-synchronization-service)
+<br><nbsp>
 
-#### Stop the Synchronization Service
+#### 1. Stop the Synchronization Service
 First you can stop the service in the Windows Service Control Manager.  Make sure that the service isn't running when attempting to stop it.  If it is, wait until it completes and then stop it.
 
 
 1. Go to Windows Service Control Manager (START → Services).
 2. Select **Microsoft Entra ID Sync** and click Stop.
 
-#### Abandon the existing encryption key
+<br><nbsp>
+
+#### 2. Abandon the existing encryption key
 Abandon the existing encryption key so that new encryption key can be created:
 
 1. Sign in to your Microsoft Entra Connect Server as administrator.
@@ -77,7 +81,18 @@ Abandon the existing encryption key so that new encryption key can be created:
 
 ![Screenshot that shows PowerShell after running the command.](./media/how-to-connect-sync-change-serviceacct-pass/key5.png)
 
-#### Provide the password of the AD DS Connector account
+<br><nbsp>
+
+#### 3. Start the Synchronization Service
+Now that the Synchronization Service has access to the encryption key and all the passwords it needs, you can restart the service in the Windows Service Control Manager:
+
+
+1. Go to Windows Service Control Manager (START → Services).
+2. Select **Microsoft Entra ID Sync** and click Restart.
+
+<br><nbsp>
+
+#### 4. Provide the password of the AD DS Connector account
 As the existing passwords stored inside the database can no longer be decrypted, you need to provide the Synchronization Service with the password of the AD DS Connector account. The Synchronization Service encrypts the passwords using the new encryption key:
 
 1. Start the Synchronization Service Manager (START → Synchronization Service).
@@ -90,7 +105,9 @@ As the existing passwords stored inside the database can no longer be decrypted,
 1. Click **OK** to save the new password and close the pop-up dialog.
 ![Screenshot that shows the "Connect to Active Directory Forest" page in the "Properties" window.](./media/how-to-connect-sync-change-serviceacct-pass/key6.png)
 
-#### Reinitialize the password of the Entra ID Connector account
+<br><nbsp>
+
+#### 5. Reinitialize the password of the Entra ID Connector account
 
 You can't directly provide the password of the Microsoft Entra Id connector account to the Synchronization Service. Instead, you need to use the cmdlet **Add-ADSyncAADServiceAccount** to reinitialize the Microsoft Entra Id Connector account. The cmdlet resets the account password and makes it available to the Synchronization Service:
 
@@ -103,12 +120,6 @@ You can't directly provide the password of the Microsoft Entra Id connector acco
 The cmdlet resets the password for the Entra Id Connector account and updates it in Microsoft Entra ID and the Synchronization Service.
 
 
-#### Re-Start the Synchronization Service
-Now that the Synchronization Service has access to the encryption key and all the passwords it needs, you can restart the service in the Windows Service Control Manager:
-
-
-1. Go to Windows Service Control Manager (START → Services).
-2. Select **Microsoft Entra ID Sync** and click Restart.
 
 ## Next steps
 **Overview topics**

--- a/docs/identity/hybrid/connect/how-to-connect-sync-change-serviceacct-pass.md
+++ b/docs/identity/hybrid/connect/how-to-connect-sync-change-serviceacct-pass.md
@@ -57,27 +57,27 @@ If you need to abandon the encryption key, use the following procedures to accom
 
 5. [Reinitialize the password of the Entra ID Connector account](#reinitialize-the-password-of-the-entra-id-connector-account)
 
-<br><nbsp>
-
+  
+  
 #### 1. Stop the Synchronization Service
 First you can stop the service in the Windows Service Control Manager.  Make sure that the service isn't running when attempting to stop it.  If it is, wait until it completes and then stop it.
 
 
-1. Go to Windows Service Control Manager (START → Services).
-2. Select **Microsoft Entra ID Sync** and click Stop.
+1.1. Go to Windows Service Control Manager (START → Services).
+1.2. Select **Microsoft Entra ID Sync** and click Stop.
 
   
   
 #### 2. Abandon the existing encryption key
 Abandon the existing encryption key so that new encryption key can be created:
 
-1. Sign in to your Microsoft Entra Connect Server as administrator.
+2.1. Sign in to your Microsoft Entra Connect Server as administrator.
 
-2. Start a new PowerShell session.
+2.2. Start a new PowerShell session.
 
-3. Navigate to folder: `'$env:ProgramFiles\Microsoft Azure AD Sync\bin\'`
+2.3. Navigate to folder: `'$env:ProgramFiles\Microsoft Azure AD Sync\bin\'`
 
-4. Run the command: `./miiskmu.exe /a`
+2.4. Run the command: `./miiskmu.exe /a`
 
 ![Screenshot that shows PowerShell after running the command.](./media/how-to-connect-sync-change-serviceacct-pass/key5.png)
 
@@ -87,37 +87,37 @@ Abandon the existing encryption key so that new encryption key can be created:
 Now that the Synchronization Service has access to the encryption key and all the passwords it needs, you can restart the service in the Windows Service Control Manager:
 
 
-1. Go to Windows Service Control Manager (START → Services).
-2. Select **Microsoft Entra ID Sync** and click Restart.
+3.1. Go to Windows Service Control Manager (START → Services).
+3.2. Select **Microsoft Entra ID Sync** and click Restart.
 
   
   
 #### 4. Provide the password of the AD DS Connector account
 As the existing passwords stored inside the database can no longer be decrypted, you need to provide the Synchronization Service with the password of the AD DS Connector account. The Synchronization Service encrypts the passwords using the new encryption key:
 
-1. Start the Synchronization Service Manager (START → Synchronization Service).
+4.1. Start the Synchronization Service Manager (START → Synchronization Service).
 </br>![Sync Service Manager](./media/how-to-connect-sync-change-serviceacct-pass/startmenu.png)  
-2. Go to the **Connectors** tab.
-3. Select the **AD Connector** that corresponds to your on-premises AD. If you have more than one AD connector, repeat the following steps for each of them.
-4. Under **Actions**, select **Properties**.
-5. In the pop-up dialog, select **Connect to Active Directory Forest**:
-6. Enter the password of the AD DS connector account in the **Password** textbox. If you don't know its password, you must set it to a known value before performing this step.
-7. Click **OK** to save the new password and close the pop-up dialog.
+4.2. Go to the **Connectors** tab.
+4.3. Select the **AD Connector** that corresponds to your on-premises AD. If you have more than one AD connector, repeat the following steps for each of them.
+4.4. Under **Actions**, select **Properties**.
+4.5. In the pop-up dialog, select **Connect to Active Directory Forest**:
+4.6. Enter the password of the AD DS connector account in the **Password** textbox. If you don't know its password, you must set it to a known value before performing this step.
+4.7. Click **OK** to save the new password and close the pop-up dialog.
 ![Screenshot that shows the "Connect to Active Directory Forest" page in the "Properties" window.](./media/how-to-connect-sync-change-serviceacct-pass/key6.png)
 
   
   
 #### 5. Reinitialize the password of the Entra ID Connector account
 
-You can't directly provide the password of the Microsoft Entra Id connector account to the Synchronization Service. Instead, you need to use the cmdlet **Add-ADSyncAADServiceAccount** to reinitialize the Microsoft Entra Id Connector account. The cmdlet resets the account password and makes it available to the Synchronization Service:
+You can't directly provide the password of the Microsoft Entra ID connector account to the Synchronization Service. Instead, you need to use the cmdlet **Add-ADSyncAADServiceAccount** to reinitialize the Microsoft Entra ID Connector account. The cmdlet resets the account password and makes it available to the Synchronization Service:
 
-1. Sign in to the Microsoft Entra Connect Sync server and open PowerShell.
-2. To provide the Microsoft Entra Id Global Administrator credentials, run `$credential = Get-Credential`.
-3. Run the cmdlet `Add-ADSyncAADServiceAccount -AADCredential $credential`.
+5.1. Sign in to the Microsoft Entra Connect Sync server and open PowerShell.
+5.2. To provide the Microsoft Entra ID Global Administrator credentials, run `$credential = Get-Credential`.
+5.3. Run the cmdlet `Add-ADSyncAADServiceAccount -AADCredential $credential`.
  
    If the cmdlet is successful, the PowerShell command prompt appears. 
    
-The cmdlet resets the password for the Entra Id Connector account and updates it in Microsoft Entra ID and the Synchronization Service.
+The cmdlet resets the password for the Entra ID Connector account and updates it in Microsoft Entra ID and the Synchronization Service.
 
 
 

--- a/docs/identity/hybrid/connect/how-to-connect-sync-change-serviceacct-pass.md
+++ b/docs/identity/hybrid/connect/how-to-connect-sync-change-serviceacct-pass.md
@@ -10,7 +10,7 @@ ms.subservice: hybrid-connect
 ms.custom: sfi-ga-nochange, sfi-image-nochange
 ---
 # Changing the ADSync service account password
-Changing the ADSync service account password can prevent the Synchronization Service from starting successfully. When this occurs, the encryption key must be discarded and re-created, and the passwords for both the AD Connector account and the Microsoft Entra ID Connect account must be re-condfigured. 
+Changing the ADSync service account password can prevent the Synchronization Service from starting successfully. When this occurs, the encryption key must be discarded and re-created, and the passwords for both the AD Connector account and the Microsoft Entra ID Connect account must be reconfigured. 
 
 >[!IMPORTANT]
 > If you use Connect with a build from 2017 March or earlier, then you should not reset the password on the service account since Windows destroys the encryption keys for security reasons. You can't change the account to any other account without reinstalling Microsoft Entra Connect. If you upgrade to a build from 2017 April or later, then it is supported to change the password on the service account, but you can't change the account used. 

--- a/docs/identity/hybrid/connect/how-to-connect-sync-change-serviceacct-pass.md
+++ b/docs/identity/hybrid/connect/how-to-connect-sync-change-serviceacct-pass.md
@@ -15,7 +15,7 @@ Changing the ADSync service account password can prevent the Synchronization Ser
 >[!IMPORTANT]
 > If you use Connect with a build from 2017 March or earlier, then you should not reset the password on the service account since Windows destroys the encryption keys for security reasons. You can't change the account to any other account without reinstalling Microsoft Entra Connect. If you upgrade to a build from 2017 April or later, then it is supported to change the password on the service account, but you can't change the account used. 
 
-Microsoft Entra Connect, as part of the Synchronization Services uses an encryption key to store the passwords of the AD DS Connector account and Entra ID Connector  account. These accounts are encrypted before they're stored in the database. 
+Microsoft Entra Connect, as part of the Synchronization Service, uses an encryption key to store the passwords of the AD DS Connector account and Microsoft Entra ID Connector account. These accounts are encrypted before they're stored in the database. 
 
 The encryption key used is secured using [Windows Data Protection (DPAPI)](/previous-versions/ms995355(v=msdn.10)). DPAPI protects the encryption key using the **ADSync service account**. 
 
@@ -55,7 +55,7 @@ If you need to abandon the encryption key, use the following procedures to accom
    
 4. [Provide the password of the AD DS Connector account](#provide-the-password-of-the-ad-ds-connector-account)
 
-5. [Reinitialize the password of the Entra Id Connector account](#reinitialize-the-password-of-the-entra-id-connector-account)
+5. [Reinitialize the password of the Entra ID Connector account](#reinitialize-the-password-of-the-entra-id-connector-account)
 
 <br><nbsp>
 

--- a/docs/identity/hybrid/connect/how-to-connect-sync-change-serviceacct-pass.md
+++ b/docs/identity/hybrid/connect/how-to-connect-sync-change-serviceacct-pass.md
@@ -10,7 +10,7 @@ ms.subservice: hybrid-connect
 ms.custom: sfi-ga-nochange, sfi-image-nochange
 ---
 # Changing the ADSync service account password
-Changing the ADSync service account password can prevent the Synchronization Service from starting successfully. When this occurs, the encryption key must be discarded and re-created, and the passwords for both the AD Connector account and the Microsoft Entra ID Connect account must be reconfigured. 
+Changing the ADSync service account password can prevent the Synchronization Service from starting successfully. When this occurs, the encryption key must be discarded and re-created, and the passwords for both the AD Connector account and the Microsoft Entra ID Connector account must be reconfigured. 
 
 >[!IMPORTANT]
 > If you use Connect with a build from 2017 March or earlier, then you should not reset the password on the service account since Windows destroys the encryption keys for security reasons. You can't change the account to any other account without reinstalling Microsoft Entra Connect. If you upgrade to a build from 2017 April or later, then it is supported to change the password on the service account, but you can't change the account used. 

--- a/docs/identity/hybrid/connect/how-to-connect-sync-change-serviceacct-pass.md
+++ b/docs/identity/hybrid/connect/how-to-connect-sync-change-serviceacct-pass.md
@@ -49,13 +49,13 @@ If you need to abandon the encryption key, use the following procedures to accom
 
 1. [Stop the Synchronization Service](#1-stop-the-synchronization-service)
 
-2. [Abandon the existing encryption key](#2-abandon-the-existing-encryption-key)
+1. [Abandon the existing encryption key](#2-abandon-the-existing-encryption-key)
 
-3. [Start the Synchronization Service](#3-start-the-synchronization-service)
+1. [Start the Synchronization Service](#3-start-the-synchronization-service)
    
-4. [Provide the password of the AD DS Connector account](#4-provide-the-password-of-the-ad-ds-connector-account)
+1. [Provide the password of the AD DS Connector account](#4-provide-the-password-of-the-ad-ds-connector-account)
 
-5. [Reinitialize the password of the Entra ID Connector account](#5-reinitialize-the-password-of-the-entra-id-connector-account)
+1. [Reinitialize the password of the Entra ID Connector account](#5-reinitialize-the-password-of-the-entra-id-connector-account)
 
   
   
@@ -63,21 +63,21 @@ If you need to abandon the encryption key, use the following procedures to accom
 First you can stop the service in the Windows Service Control Manager.  Make sure that the service isn't running when attempting to stop it.  If it is, wait until it completes and then stop it.
 
 
-1.1. Go to Windows Service Control Manager (START → Services).
-1.2. Select **Microsoft Entra ID Sync** and click Stop.
+a. Go to Windows Service Control Manager (START → Services).
+b. Select **Microsoft Entra ID Sync** and click Stop.
 
   
   
 #### 2. Abandon the existing encryption key
 Abandon the existing encryption key so that new encryption key can be created:
 
-2.1. Sign in to your Microsoft Entra Connect Server as administrator.
+a. Sign in to your Microsoft Entra Connect Server as administrator.
 
-2.2. Start a new PowerShell session.
+b. Start a new PowerShell session.
 
-2.3. Navigate to folder: `'$env:ProgramFiles\Microsoft Azure AD Sync\bin\'`
+c. Navigate to folder: `'$env:ProgramFiles\Microsoft Azure AD Sync\bin\'`
 
-2.4. Run the command: `./miiskmu.exe /a`
+d.  Run the command: `./miiskmu.exe /a`
 
 ![Screenshot that shows PowerShell after running the command.](./media/how-to-connect-sync-change-serviceacct-pass/key5.png)
 
@@ -87,22 +87,22 @@ Abandon the existing encryption key so that new encryption key can be created:
 Now that the Synchronization Service has access to the encryption key and all the passwords it needs, you can restart the service in the Windows Service Control Manager:
 
 
-3.1. Go to Windows Service Control Manager (START → Services).
-3.2. Select **Microsoft Entra ID Sync** and click Restart.
+a. Go to Windows Service Control Manager (START → Services).
+b. Select **Microsoft Entra ID Sync** and click Restart.
 
   
   
 #### 4. Provide the password of the AD DS Connector account
 As the existing passwords stored inside the database can no longer be decrypted, you need to provide the Synchronization Service with the password of the AD DS Connector account. The Synchronization Service encrypts the passwords using the new encryption key:
 
-4.1. Start the Synchronization Service Manager (START → Synchronization Service).
+a. Start the Synchronization Service Manager (START → Synchronization Service).
 </br>![Sync Service Manager](./media/how-to-connect-sync-change-serviceacct-pass/startmenu.png)  
-4.2. Go to the **Connectors** tab.
-4.3. Select the **AD Connector** that corresponds to your on-premises AD. If you have more than one AD connector, repeat the following steps for each of them.
-4.4. Under **Actions**, select **Properties**.
-4.5. In the pop-up dialog, select **Connect to Active Directory Forest**:
-4.6. Enter the password of the AD DS connector account in the **Password** textbox. If you don't know its password, you must set it to a known value before performing this step.
-4.7. Click **OK** to save the new password and close the pop-up dialog.
+b. Go to the **Connectors** tab.
+c. Select the **AD Connector** that corresponds to your on-premises AD. If you have more than one AD connector, repeat the following steps for each of them.
+d. Under **Actions**, select **Properties**.
+e. In the pop-up dialog, select **Connect to Active Directory Forest**:
+f. Enter the password of the AD DS connector account in the **Password** textbox. If you don't know its password, you must set it to a known value before performing this step.
+g. Click **OK** to save the new password and close the pop-up dialog.
 ![Screenshot that shows the "Connect to Active Directory Forest" page in the "Properties" window.](./media/how-to-connect-sync-change-serviceacct-pass/key6.png)
 
   
@@ -111,9 +111,9 @@ As the existing passwords stored inside the database can no longer be decrypted,
 
 You can't directly provide the password of the Microsoft Entra ID connector account to the Synchronization Service. Instead, you need to use the cmdlet **Add-ADSyncAADServiceAccount** to reinitialize the Microsoft Entra ID Connector account. The cmdlet resets the account password and makes it available to the Synchronization Service:
 
-5.1. Sign in to the Microsoft Entra Connect Sync server and open PowerShell.
-5.2. To provide the Microsoft Entra ID Global Administrator credentials, run `$credential = Get-Credential`.
-5.3. Run the cmdlet `Add-ADSyncAADServiceAccount -AADCredential $credential`.
+a. Sign in to the Microsoft Entra Connect Sync server and open PowerShell.
+b. To provide the Microsoft Entra ID Global Administrator credentials, run `$credential = Get-Credential`.
+c. Run the cmdlet `Add-ADSyncAADServiceAccount -AADCredential $credential`.
  
    If the cmdlet is successful, the PowerShell command prompt appears. 
    

--- a/docs/identity/hybrid/connect/how-to-connect-sync-change-serviceacct-pass.md
+++ b/docs/identity/hybrid/connect/how-to-connect-sync-change-serviceacct-pass.md
@@ -19,7 +19,7 @@ Microsoft Entra Connect, as part of the Synchronization Service, uses an encrypt
 
 The encryption key used is secured using [Windows Data Protection (DPAPI)](/previous-versions/ms995355(v=msdn.10)). DPAPI protects the encryption key using the **ADSync service account**. 
 
-If you need to change the ADSync service account password you can use the procedures in [Abandoning the ADSync service account encryption key](#abandoning-the-adsync-service-account-encryption-key) to accomplish this.  These procedures should also be used if you need to abandon the encryption key for any reason.
+If you need to change the ADSync service account password, you can use the procedures in [Abandoning the ADSync service account encryption key](#abandoning-the-adsync-service-account-encryption-key) to accomplish this. These procedures should also be used if you need to abandon the encryption key for any reason.
 
 ## Issues that arise from changing the password
 There are two things that need to be done when you change the ADSync service account password.

--- a/docs/identity/hybrid/connect/how-to-connect-sync-change-serviceacct-pass.md
+++ b/docs/identity/hybrid/connect/how-to-connect-sync-change-serviceacct-pass.md
@@ -12,7 +12,7 @@ ms.custom: sfi-ga-nochange, sfi-image-nochange
 # Changing the ADSync service account password
 Changing the ADSync service account password can prevent the Synchronization Service from starting successfully. When this occurs, the encryption key must be discarded and re-created, and the passwords for both the AD Connector account and the Microsoft Entra ID Connector account must be reconfigured. 
 
->[!IMPORTANT]
+> [!IMPORTANT]
 > If you use Connect with a build from 2017 March or earlier, then you should not reset the password on the service account since Windows destroys the encryption keys for security reasons. You can't change the account to any other account without reinstalling Microsoft Entra Connect. If you upgrade to a build from 2017 April or later, then it is supported to change the password on the service account, but you can't change the account used. 
 
 Microsoft Entra Connect, as part of the Synchronization Service, uses an encryption key to store the passwords of the AD DS Connector account and Microsoft Entra ID Connector account. These accounts are encrypted before they're stored in the database. 

--- a/docs/identity/hybrid/connect/how-to-connect-sync-change-serviceacct-pass.md
+++ b/docs/identity/hybrid/connect/how-to-connect-sync-change-serviceacct-pass.md
@@ -49,7 +49,7 @@ If you need to abandon the encryption key, use the following procedures to accom
 
 1. [Stop the Synchronization Service](#stop-the-synchronization-service)
 
-1. [Abandon the existing encryption key](#abandon-the-existing-encryption-key)
+2. [Abandon the existing encryption key](#abandon-the-existing-encryption-key)
 
 3. [Start the Synchronization Service](#start-the-synchronization-service)
    
@@ -66,8 +66,8 @@ First you can stop the service in the Windows Service Control Manager.  Make sur
 1. Go to Windows Service Control Manager (START → Services).
 2. Select **Microsoft Entra ID Sync** and click Stop.
 
-<br><nbsp>
-
+  
+  
 #### 2. Abandon the existing encryption key
 Abandon the existing encryption key so that new encryption key can be created:
 
@@ -81,8 +81,8 @@ Abandon the existing encryption key so that new encryption key can be created:
 
 ![Screenshot that shows PowerShell after running the command.](./media/how-to-connect-sync-change-serviceacct-pass/key5.png)
 
-<br><nbsp>
-
+  
+  
 #### 3. Start the Synchronization Service
 Now that the Synchronization Service has access to the encryption key and all the passwords it needs, you can restart the service in the Windows Service Control Manager:
 
@@ -90,8 +90,8 @@ Now that the Synchronization Service has access to the encryption key and all th
 1. Go to Windows Service Control Manager (START → Services).
 2. Select **Microsoft Entra ID Sync** and click Restart.
 
-<br><nbsp>
-
+  
+  
 #### 4. Provide the password of the AD DS Connector account
 As the existing passwords stored inside the database can no longer be decrypted, you need to provide the Synchronization Service with the password of the AD DS Connector account. The Synchronization Service encrypts the passwords using the new encryption key:
 
@@ -102,11 +102,11 @@ As the existing passwords stored inside the database can no longer be decrypted,
 4. Under **Actions**, select **Properties**.
 5. In the pop-up dialog, select **Connect to Active Directory Forest**:
 6. Enter the password of the AD DS connector account in the **Password** textbox. If you don't know its password, you must set it to a known value before performing this step.
-1. Click **OK** to save the new password and close the pop-up dialog.
+7. Click **OK** to save the new password and close the pop-up dialog.
 ![Screenshot that shows the "Connect to Active Directory Forest" page in the "Properties" window.](./media/how-to-connect-sync-change-serviceacct-pass/key6.png)
 
-<br><nbsp>
-
+  
+  
 #### 5. Reinitialize the password of the Entra ID Connector account
 
 You can't directly provide the password of the Microsoft Entra Id connector account to the Synchronization Service. Instead, you need to use the cmdlet **Add-ADSyncAADServiceAccount** to reinitialize the Microsoft Entra Id Connector account. The cmdlet resets the account password and makes it available to the Synchronization Service:

--- a/docs/identity/hybrid/connect/how-to-connect-sync-change-serviceacct-pass.md
+++ b/docs/identity/hybrid/connect/how-to-connect-sync-change-serviceacct-pass.md
@@ -47,15 +47,15 @@ Use the following procedures to abandon the encryption key.
 
 If you need to abandon the encryption key, use the following procedures to accomplish that.
 
-1. [Stop the Synchronization Service](#stop-the-synchronization-service)
+1. [Stop the Synchronization Service](#1-stop-the-synchronization-service)
 
-2. [Abandon the existing encryption key](#abandon-the-existing-encryption-key)
+2. [Abandon the existing encryption key](#2-abandon-the-existing-encryption-key)
 
-3. [Start the Synchronization Service](#start-the-synchronization-service)
+3. [Start the Synchronization Service](#3-start-the-synchronization-service)
    
-4. [Provide the password of the AD DS Connector account](#provide-the-password-of-the-ad-ds-connector-account)
+4. [Provide the password of the AD DS Connector account](#4-provide-the-password-of-the-ad-ds-connector-account)
 
-5. [Reinitialize the password of the Entra ID Connector account](#reinitialize-the-password-of-the-entra-id-connector-account)
+5. [Reinitialize the password of the Entra ID Connector account](#5-reinitialize-the-password-of-the-entra-id-connector-account)
 
   
   


### PR DESCRIPTION
Updated references to ADSync service account and Entra ID Connector account for clarity and consistency. Adjusted instructions regarding password changes and encryption key handling.