### PR TITLE
Fix spelling of 'Microsoft' in app sign-in flow diagram

### DIFF
--- a/docs/identity-platform/app-sign-in-flow.md
+++ b/docs/identity-platform/app-sign-in-flow.md
@@ -35,6 +35,8 @@ The following sequence diagram summarizes this interaction:
 
 ![web app authentication process](media/authentication-scenarios/web-app-how-it-appears-to-be.png)
 
+"Microsoft" is misspelt in this diagram above
+
 ### How a web app determines if the user is authenticated
 
 Web app developers can indicate whether all or only certain pages require authentication. For example, in ASP.NET/ASP.NET Core, this is done by adding the `[Authorize]` attribute to the controller actions.


### PR DESCRIPTION
This pull request makes a minor documentation update to the `app-sign-in-flow.md` file. It adds a note that "Microsoft" is misspelt in the referenced diagram.

- Documentation update:
  * Added a note to the sequence diagram section in `docs/identity-platform/app-sign-in-flow.md` indicating that "Microsoft" is misspelt in the diagram. Please correct the spelling of 'Microsoft' in the sequence diagram.