### PR TITLE
Fix Creatio SAML Identifier URL example

### DIFF
--- a/docs/identity/saas-apps/bpmonline-tutorial.md
+++ b/docs/identity/saas-apps/bpmonline-tutorial.md
@@ -74,7 +74,7 @@ Follow these steps to enable Microsoft Entra SSO.
 
     | Identifier |
     |-------------|
-    | `https://<SUBDOMAIN>.creatio.com/` |
+    | `https://<SUBDOMAIN>.creatio.com` |
 
     b. In the **Reply URL** text box, type a URL using one of the following patterns:
 


### PR DESCRIPTION
This PR removes the trailing slash from the Creatio SAML Identifier URL example.

The current value:

https://<SUBDOMAIN>.creatio.com/

should be:

https://<SUBDOMAIN>.creatio.com

The trailing slash can cause incorrect SSO configuration for Creatio.