### PR TITLE
Update howto-vm-sign-in-azure-ad-linux.md

### DIFF
--- a/docs/identity/devices/howto-vm-sign-in-azure-ad-linux.md
+++ b/docs/identity/devices/howto-vm-sign-in-azure-ad-linux.md
@@ -38,7 +38,7 @@ The following Linux distributions are currently supported for deployments in a s
 | Debian | Debian 9, Debian 10, Debian 11, Debian 12 |
 | openSUSE | openSUSE Leap 42.3, openSUSE Leap 15.1 to 15.5, openSUSE Leap 15.6+ |
 | Oracle | Oracle Linux 8, Oracle Linux 9 |
-| RedHat Enterprise Linux (RHEL) | RHEL 7.4 to RHEL 7.9, RHEL 8.3+, RHEL 9.0+ |
+| RedHat Enterprise Linux (RHEL) | RHEL 7.4 to RHEL 7.9, RHEL 8.3+, RHEL 9.0+, RHEL 10.1 |
 | Rocky | Rocky 8, Rocky 9 |
 | SUSE Linux Enterprise Server (SLES) | SLES 12, SLES 15.1 to 15.5, SLES 15.6+ |
 | Ubuntu | Ubuntu 16.04 to Ubuntu 24.04 |


### PR DESCRIPTION
As confirmed by a Senior Software Engineer working with Linux, in reply to the AVA post raised due to a customer question, (AVA post with link bellow), we do support the new RHRL version 10.1. Adding a change include the version 10.1 on the list of supported versions.
 "https://teams.microsoft.com/l/message/19:a29fe6245d444591b9087e6e20a9076b@thread.skype/1773743114890?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=0f0f4ddf-6429-4dfe-83d2-1a28cb88fadd&parentMessageId=1773743114890&teamName=Cloud%20Identity%20-%20Authentication&channelName=Azure%20VM%20AAD%20Sign-in&createdTime=1773743114890"

<img width="1102" height="726" alt="AVA Case 2603130030004026" src="https://github.com/user-attachments/assets/0e5fac33-9c13-41e7-8e61-f2647d78b3d2" />
