### PR TITLE
Update role requirements for custom authentication strength

### DIFF
--- a/docs/identity/authentication/concept-authentication-strength-advanced-options.md
+++ b/docs/identity/authentication/concept-authentication-strength-advanced-options.md
@@ -18,7 +18,7 @@ An authentication strength is a Microsoft Entra Conditional Access control that 
 
 ## Create a custom authentication strength
 
-1. Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com) as at least a [Security Administrator](~/identity/role-based-access-control/permissions-reference.md#security-administrator).
+1. Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com) as at least a [Conditional Access Administrator](~/identity/role-based-access-comtrol/permissions-reference.md#conditional-access-administrator) or [Security Administrator](~/identity/role-based-access-control/permissions-reference.md#security-administrator).
 
 1. Browse to **Entra ID** > **Authentication methods** > **Authentication strengths**.
 


### PR DESCRIPTION
Doc mentioned that doing this action required at least Security Administrator, which is not correct (according to https://learn.microsoft.com/en-us/graph/api/authenticationstrengthpolicy-update?view=graph-rest-1.0&tabs=http), since Conditional Access Administrator also allows to perform the action and is arguably less privileged. So, changed the doc to indicate that either Conditional Access Administrator or Security Administrator can do it.

Alternatively, Security Administrator can be removed all together, leaving only Conditional Access Administrator.