### PR TITLE
docs: Add known issues to macOS PSSO troubleshooting page

### DIFF
--- a/docs/identity/devices/troubleshoot-macos-platform-single-sign-on-extension.md
+++ b/docs/identity/devices/troubleshoot-macos-platform-single-sign-on-extension.md
@@ -2,23 +2,25 @@
 title: macOS Platform single sign-on known issues and troubleshooting
 description: Identify and resolve known issues with macOS Platform single sign-on (PSSO).
 
+ms.service: entra-id
+ms.subservice: devices
 ms.topic: troubleshooting
-ms.date: 12/19/2024
+ms.date: 11/03/2023
 
 ms.author: cwerner
 author: cilwerner
-manager: pmwongera
+manager: CelesteDG
 ms.reviewer: brianmel, miepping
 #Customer intent: As a customer, I want to understand how to troubleshoot macOS Platform single sign-on (PSSO) issues, have some frequently asked questions answered, and understand different scenarios to validate.
 ---
 
-# macOS Platform single sign-on known issues and troubleshooting
+# macOS Platform single sign-on known issues and troubleshooting (preview)
 
 This article outlines the current known issues and common questions with macOS Platform single sign-on (PSSO). It provides issue solutions and information on how to report an issue that isn't covered. This article also includes troubleshooting guidance.
 
 ## Scenarios to validate
 
-Once PSSO is deployed on your device, there are a few validation scenarios that you can do to ensure that the deployment is successful. If there are any issues, refer to [report an issue](#report-an-issue) for further instructions.
+After deploying PSSO on your device, there are a few validation scenarios that you can do to ensure that the deployment is successful. If there are any issues, refer to [report an issue](#report-an-issue) for further instructions.
 
 ### Password change events
 
@@ -42,16 +44,16 @@ You can also deregister the device completely by doing the following steps.
 
 ### [macOS 13](#tab/macOS13)
 
-On macOS 13 Ventura, if there are problems with your device PSSO registration, or you need to deregister your device, use the Company Portal to remove the device from your organization.
+On macOS 13 Ventura, if there are problems with your device PSSO registration, or you need to deregister your device, use Company Portal and remove the device from your organization.
 
 1. Open the **Company Portal** app and navigate to **Preferences**.
 1. To Deregister the device, select **Deregister**.
 
-If you deregistered your device as a result of an error, refer to [Join a Mac device with Microsoft Entra ID during the out of box experience](./device-join-macos-platform-single-sign-on.md) or [Join a Mac device with Microsoft Entra ID using Company Portal](./device-join-microsoft-entra-company-portal.md) to re-register the device.
+If you deregistered your device as a result of an error, and need to re-register it, refer to [Join a Mac device with Microsoft Entra ID during the out of box experience](./device-join-macos-platform-single-sign-on.md) or [Join a Mac device with Microsoft Entra ID using Company Portal](./device-join-microsoft-entra-company-portal.md).
 
 ---
 
-### Enterprise Single sign-on (SSO) plug-in doesn't activate after system update
+### Enterprise SSO plug-in does not activate after system update
 
 If the Enterprise SSO plug-in fails to activate after system updates are applied to the device, you should reboot the software update daemon.
 
@@ -61,41 +63,15 @@ If the Enterprise SSO plug-in fails to activate after system updates are applied
     sudo killall swcd
     ```
 
-2. Enter the following command to reset the process.
+2. Then enter the following command to reset the process.
 
     ```console
     sudo swcutil reset
     ```
-### TLS Inspection URLs to be excluded for Platform SSO
 
-#### 1. URLs that need to be allowed for PSSO registration flows
-Ensure that traffic to the URLs listed **[here](./plan-device-deployment.md#network-requirements-for-device-registration-with-microsoft-entra)** is allowed by default and explicitly exempted from TLS interception or inspection. This is critical for registration and device auth flows that rely on TLS challenges to complete successfully.
+### Temporary passwords issued during password reset cannot be synced with Platform SSO
 
-#### 2. URLs that need to be exempted for PSSO token acquisition and token refresh flows
-Ensure below URLs are exempted from TLS interception/inspection so that Platform SSO token acquisition and refresh can be successfully performed on Platform SSO targeted devices:
-
-- app-site-association.cdn-apple.com
-- app-site-association.networking.apple
-- login.microsoftonline.com
-- login.microsoft.com
-- sts.windows.net
-- login.partner.microsoftonline.cn(*)
-- login.chinacloudapi.cn(*)
-- login.microsoftonline.us(*)
-- login-us.microsoftonline.com(*)
-- config.edge.skype.com(**)
-
-Apple's app-site-association domains are critical for SSO extension functioning. (*) You only need to allow sovereign cloud domains if you rely on those in your environment. (**) Maintaining communications with the Experimentation Configuration Service (ECS) ensures that Microsoft can respond to a severe bug in a timely manner. 
-
-> [!NOTE] 
-> Platform SSO isn't compatible with the Microsoft Entra ID Tenant Restrictions v2 feature when Tenant Restrictions are deployed using a corporate proxy. Alternate option is listed in [TRv2 Known limitation](/entra/external-id/tenant-restrictions-v2#known-limitation)
-
-> [!IMPORTANT]
-> **Note: There has been a recent update to the TLS endpoint used in registration flows. Please verify that your environment’s allowlist reflects the latest URL requirements to avoid disruptions.**
-
-### Temporary passwords issued during password reset can't be synced with Platform SSO
-
-Temporary passwords issued during password reset can't be synced to the local device. Users are advised to complete the password reset process using their temporary password using the SSO extension.
+Temporary passwords issued during password reset cannot be synced to the local device. Users are advised to complete the password reset process using their temporary password using the SSO extension.
 
 ### Device migration
 
@@ -107,49 +83,7 @@ Confirm that a previously registered device (with a Workplace Join key in Keycha
 
 No, macOS PSSO is only supported in Microsoft Entra join deployments. There are no plans to support hybrid-join deployments, as we recommend that Mac users go fully cloud based.
 
-### How can I change my password when using Platform SSO?
-
-Users can change their password using Self-Service Password Reset (SSPR) on their device. 
-
-If SSPR is done on another machine, users are allowed to sign-in to the Mac device using either the old or the new password. Using the old password unlocks the device and then prompt the user for the new password to continue syncing data. Using the new password unlocks the device and sync data immediately.
-
-We recommend that IT Admins should use [Managed Apple IDs](https://support.apple.com/guide/deployment/depcaa668a58/web) where possible as this does give organizations more options for password management.
-
-### What should I do if I forget my password?
-
-#### Password Sync
-
-Users can reset their password at the login screen or lock screen. If the user received a temporary password from an IT admin they should use another device to sign in, set up a new password and use that new password at the login prompt to their own device. For more info, refer [Apple's documentation on forgotten passwords](https://support.apple.com/102633).
-
-> [!IMPORTANT] 
-> There's a known issue with PSSO that's causing registration removal during recovery and may prompt users to re-register after recovery. This is expected behavior.
-
-IT Admins should also enable Keyvault recovery to ensure data can be recovered in case of a forgotten password. To learn more, refer to [Configure Platform SSO for macOS devices in Microsoft Intune](/mem/intune/configuration/platform-sso-macos#password).
-
-> [!NOTE] 
-> If the device is booted and there's FileVault encryption the new Microsoft Entra password will work on macOS15 only. 
-
-#### Secure Enclave
-Users can reset the local password via Apple ID or an admin recovery key. 
-
 ## Known issues
-
-### Unexpected/frequent re-registration prompts on macOS Sequoia
-
-> [!NOTE]
-> Latest update on the PSSO re-registration issue on macOS 15.x described below: Apple confirmed the fix is deployed in macOS 15.3. If users still experience the re-registration issue on macOS 15.3+, please engage with Apple and share the logs via Apple support.
-
-There's a known concurrency issue on macOS 15+ (Sequoia) that can cause the PSSO device configuration to become corrupted. The device configuration can be corrupted by simultaneous updates from the system AppSSOAgent and AppSSODaemon processes. The corrupted configuration causes the operating system to trigger its re-registration remediation flow, resulting in unexpected registration prompts for users.
-
-This issue is currently being investigated by Apple.
-
-Sysdiagnose logs from affected users contain the following error:
-
-```
-Error Domain=com.apple.PlatformSSO Code=-1001 "Error deserializing device config." UserInfo={NSLocalizedDescription=Error deserializing device config., NSUnderlyingError=0x9480343f0 {Error Domain=NSCocoaErrorDomain Code=3840 "Garbage at end around line 27, column 1." UserInfo={NSDebugDescription=Garbage at end around line 27, column 1., NSJSONSerializationErrorIndex=3052}}}
-```
-
-We encourage users and admins who encounter this error to file an Apple Care issue and engage with Apple to resolve the issue.
 
 ### Passcode policy complexity mismatches
 
@@ -173,13 +107,31 @@ The device registration can take a few minutes to complete. If the device regist
 
 If you cancel the registration process by closing the SSO auth prompt dialog, you need to sign out from your Mac device and sign in again. Upon a successful sign in, the registration notification reappears and works correctly.
 
-### Per-user MFA causes password sync failure
+### Per user MFA causes password sync failure
 
 If a user has per user MFA enabled on the account where PSSO is being set up, you won't be able to enter Microsoft Entra ID credentials in the next steps, causing an error. To avoid this error, admins should ensure they have Conditional Access MFA enabled in accordance with [Microsoft Entra ID recommendations](../monitoring-health/recommendation-turn-off-per-user-mfa.md). This suppresses MFA during enrollment so that password synchronization can be completed successfully.
 
 ### PSSO reregistration required after password reset initiated from FileVault recovery or MDM-driven recovery
 
-Because Secure Enclave keys are protected by your local account password, password resets that occur without providing this password (such as FileVault or MDM-based recovery) resets the Secure Enclave. Resetting the Secure Enclave renders keys previously stored for this account inaccessible. Devices whose Secure Enclave keys are lost must be reregistered to use Platform SSO.
+Because Secure Enclave keys are protected by your local account password, password resets that occur without providing this password (such as FileVault or MDM-based recovery) will reset the Secure Enclave. Resetting the Secure Enclave renders keys previously stored for this account inaccessible. Devices whose Secure Enclave keys have been lost must be reregistered to use Platform SSO.
+
+### PSSO re-registration triggered after Company Portal update
+
+Updating the Company Portal app can trigger an unexpected PSSO re-registration prompt. When Company Portal is updated, the AppSSO framework reloads with `reason = ExtensionsChanged`, which can clear the Platform SSO login manager configuration. Platform SSO then returns `no login configuration data to load` and shows listener-start failures (`Code=-1008 "Did not start listening"`). After a reboot or new console session, Platform SSO enters a grace/auth-required state and delivers a new registration notification.
+
+This issue is under investigation with Apple. Rebooting the device restores Platform SSO to a functional state. Users should complete re-registration when prompted.
+
+### SSO extension temporarily unavailable after Setup Assistant enrollment
+
+The SSO extension may not be available for approximately 10–15 seconds after completing Setup Assistant–based enrollment. On the first launch of the Company Portal app after enrollment, an embedded web view is shown for sign-in instead of the expected SSO extension experience. The macOS quarantine resolver temporarily locks the SSO extension configuration, blocking its availability. This behavior has also been observed in the standard PSSO flow outside of Setup Assistant.
+
+This issue is under investigation with Apple. Closing and reopening the Company Portal app resolves the issue.
+
+### SSO failures after Setup Assistant with password sync configuration
+
+SSO can fail after PSSO registration completes in the Setup Assistant flow when using password sync as the authentication method. The Primary Refresh Token (PRT) isn't saved during device registration. When Setup Assistant completes and the PRT refresh request is sent to Microsoft Entra ID, no PRT is attached, causing an authentication failure. Users are prompted for an unexpected additional authentication before they can access resources.
+
+This issue is under investigation with Apple. A device reboot may help restore normal SSO behavior.
 
 ## Report an issue
 
@@ -202,24 +154,17 @@ We'd love to hear your feedback. You should include the following information:
 - Steps to reproduce the issue
 - Where applicable, include relevant screenshots and/or recordings
 
-### Capturing Sysdiagnose and diagnostic logs
-
-1. Enable debug logs persistence by running the following command in Terminal.
+#### Capturing Sysdiagnose and diagnostic logs
+1. Enable debug logs persistance by running the following command in Terminal.
 
     ```console
-    sudo log config --mode "level:debug,persist:debug" --subsystem "com.apple.AppSSO"
+    sudo log config --mode "level:debug,persist:debug" --subsystem com.apple.AppSSO"
     ```
-2. Reproduce the issue, such that new logs are generated for the affected scenario. Provide relevant timestamps in your issue report to help log investigation.
+2. Reproduce the issue, such that new logs are generated for the affected scenario. Please provide relevant timestamps in your issue report to assist in log investigation.
 3. Capture diagnostic data by running the following command in Terminal.
 
     ```console
     sudo sysdiagnose
-    ```
-
-4. Reset the debug logs to default settings by running the following command in Terminal.
-
-    ```console
-    sudo log config --reset --subsystem "com.apple.AppSSO"
     ```
 
 ## Troubleshooting guide
@@ -228,7 +173,7 @@ We'd love to hear your feedback. You should include the following information:
 
 If a user has insufficient permissions to complete Microsoft Entra ID join and registration, no error message is shown. For the device join and registration to complete successfully, the user initiating the registration flow must be allowlisted.
 
-1. In the [Microsoft Entra admin center](https://entra.microsoft.com/), navigate to **Entra ID** > **Devices** > **Overview** > **Device Settings**.
+1. In the [Microsoft Entra admin center](https://entra.microsoft.com/), navigate to **Identity** > **Devices** > **Overview** > **Device Settings**.
 1. Under **Microsoft Entra ID join and registration settings**, ensure that the **All** option is selected in the toggle menu for **Users may join devices to Microsoft Entra**.
 1. Select **Save** to apply the changes.
 
@@ -236,23 +181,19 @@ If a user has insufficient permissions to complete Microsoft Entra ID join and r
 
 Platform Credential as Passkey option is only available if Secure Enclave is configured as the authentication method for Platform SSO. You should check the following:
 
-1. Ensure that your admin set up your device with Secure Enclave as the authentication method, and [enabled passkeys (FIDO2) for your organization](/entra/identity/authentication/how-to-enable-passkey-fido2#enable-passkey-authentication-method).
+1. Ensure that your admin has set up your device with Secure Enclave as the authentication method, and has [enabled passkeys (FIDO2) for your organization](/entra/identity/authentication/how-to-enable-passkey-fido2#enable-passkey-authentication-method).
 1. As a user, check that you have enabled Company Portal as a passkey provider in your device settings. Navigate to your **Settings** app, **Passwords** and **Password options**, and ensure that **Company Portal** is enabled.
-
-### Troubleshoot Microsoft Edge SSO issues
- 
-If Microsoft Edge users are facing SSO issues after Platform SSO registration, check if the user has signed into the Edge profile. Users need to sign into their Edge profile for browser SSO to work with Edge on Platform SSO registered devices.
 
 ### Troubleshoot Google Chrome SSO issues
 
-For users with the [Microsoft Single Sign On](https://chromewebstore.google.com/detail/microsoft-single-sign-on/ppnbnpeolgkicgegkbkbjmhlideopiji?pli=1) extension for Google Chrome installed, then their Chrome browser should be able communicate with the Microsoft SSO broker for both an SSO user experience and to work with device-based Conditional Access policies. If users aren't able to pass device-based Conditional Access policies in Google Chrome then there may be an issue with how the Company Portal application was installed, which can prevent Chrome from communicating with the SSO broker. You should take the following steps to remediate this issue:
+If a user has the [Microsoft Single Sign On](https://chromewebstore.google.com/detail/microsoft-single-sign-on/ppnbnpeolgkicgegkbkbjmhlideopiji?pli=1) extension for Google Chrome installed then their Chrome browser should be able communicate with the Microsoft SSO broker for both a SSO user experience and to work with device-based Conditional Access policies. If users are not able to pass device-based Conditional Access policies in Google Chrome then there may be an issue with how the Company Portal application was installed, which can prevent Chrome from communicating with the SSO broker. You should take the following steps to remediate this issue:
 
 1. Open the **Applications** folder on the Mac
 1. Right click the **Company Portal** application and choose **Move to Trash**
 1. Download the latest version of the Company Portal installer from [https://go.microsoft.com/fwlink/?linkid=853070](https://go.microsoft.com/fwlink/?linkid=853070)
 1. Freshly install Company Portal using the downloaded **CompanyPortal-Installer.pkg**
 
-Validate that the issue is resolved by checking for the **existence of this file**: `~/Library/Application\ Support/Google/Chrome/NativeMessagingHosts/com.microsoft.browsercore.json`
+Validate that the issue has been resolved by checking for the **existence of this file**: `~/Library/Application\ Support/Google/Chrome/NativeMessagingHosts/com.microsoft.browsercore.json`
 
 ```console
 ls ~/Library/Application\ Support/Google/Chrome/NativeMessagingHosts/com.microsoft.browsercore.json
@@ -285,42 +226,6 @@ cp /Applications/Company\ Portal.app/Contents/Resources/com.microsoft.browsercor
 
 > [!IMPORTANT]
 > **Note: This issue is due to a bug with how Company Portal is installed or updated under certain circumstances. This issue will be resolved in a future update to Company Portal.**
-
-### Unable to sign-in – Single sign-on application is missing
-
-![Screenshot of dialog that states Unable to Sign in due to an issue with the extension while registering your account for single sign on.](./media/macos-psso/psso-simplified-setup-unable-to-sign-in.png)
-
-**Issue summary: Company Portal/SSO extension not available during Setup Assistant**
-
-In the case where configuration profiles and the Company Portal app (which provides the SSO extension) arrive late, Setup Assistant may show a missing SSO app message even though the PSSO profile has already been delivered.
-
-- The management profile/configuration can be present while Company Portal is still downloading or installing since enrollment actions occur in separate steps rather than as a single transaction.
-- Retrying using "Try again" button should succeed once Company Portal arrives.
-- If the issue persists, and the profile is updated while the setup assistant flow is in progress, the changes won't take effect until the device is wiped and started clean.
-
-### Re-enroll device with Platform SSO with EnableRegistrationDuringSetup on macOS
-
-In the case of misconfiguration, you'll need to re-enroll macOS devices. 
-
-To disable PSSO during setup, 
-1. In Intune, unassign the device from the SSO extension profile that has `EnableRegistrationDuringSetup` enabled.
-2. Assign the device to a new SSO extension profile that sets `EnableRegistrationDuringSetup` to disabled (false).
-3. Wipe the device to restart the enrollment process again.
-
-> [!NOTE]
-> Wiping the device is required to restart the enrollment process and apply the updated enrollment profiles.
-
-### To Capture Sysdiagnose and CP logs in macOS Setup Assistant
-1.	In macOS Setup Assistant, press Control + Option + Command + Shift + Period (.) to start a sysdiagnose capture.
-    - The screen may appear to freeze briefly while the capture is triggered.
-    - Logs are collected in the background and packaged into a .tar.gz file.
-2.	After you can access the system, 
-    - Retrieve sys diagnostics file from /private/var/tmp/ (sometimes /var/tmp/). File name format: sysdiagnose_YYYY.MM.DD_*.tar.gz
-    - Open company portal app and go to Help -> Send diagnostic report and share the incident ID
-3.	If the user can’t complete Setup Assistant (for example, due to a PSSO configuration error), you can still collect and share the sysdiagnose output and CP logs.
-    - Triggering sysdiagnose in Setup Assistant opens a Finder-like window showing the sysdiagnose .tar.gz file. Use AirDrop to share the file.
-    - In the same finder window, navigate to Applications tab and open Company portal app. Go to Help ->Send diagnostic report and share the incident ID.
-
 
 ## See also
 


### PR DESCRIPTION
## Summary

Adds three customer-reported known issues to the [macOS Platform SSO troubleshooting](https://learn.microsoft.com/en-us/entra/identity/devices/troubleshoot-macos-platform-single-sign-on-extension) page, all under investigation with Apple:

1. **PSSO re-registration triggered after Company Portal update** - CP update causes AppSSO framework reload, clearing login manager config and prompting unexpected re-registration.
2. **SSO extension temporarily unavailable after Setup Assistant enrollment** - SSO extension unavailable for ~10-15 seconds after enrollment due to macOS quarantine resolver locking the config.
3. **SSO failures after Setup Assistant with password sync configuration** - PRT not saved during device registration in Setup Assistant with password sync, causing authentication failures.

## Details

- All three issues are under active investigation with Apple.
- Workarounds are documented for each issue (reboot, close/reopen Company Portal).

## File changed

- docs/identity/devices/troubleshoot-macos-platform-single-sign-on-extension.md
