### PR TITLE
Document permissions for managed domain security settings

### DIFF
--- a/docs/identity/domain-services/secure-your-domain.md
+++ b/docs/identity/domain-services/secure-your-domain.md
@@ -30,6 +30,8 @@ To complete this article, you need the following resources:
     * If needed, [create a Microsoft Entra tenant][create-azure-ad-tenant] or [associate an Azure subscription with your account][associate-azure-ad-tenant].
 * A Microsoft Entra Domain Services managed domain enabled and configured in your Microsoft Entra tenant.
     * If needed, [create and configure a Microsoft Entra Domain Services managed domain][create-azure-ad-ds-instance].
+    * You need [Application Administrator](/entra/identity/role-based-access-control/permissions-reference#application-administrator) and [Groups Administrator](/entra/identity/role-based-access-control/permissions-reference#groups-administrator) Microsoft Entra roles in your tenant to modify security settings for a managed domain.
+    * You need [Domain Services Contributor](/azure/role-based-access-control/built-in-roles#domain-services-contributor) Azure role to modify security settings for a managed domain.
 
 ## Use Security settings to harden your domain
 


### PR DESCRIPTION
## Summary

Documents the permissions required to modify security settings for a Microsoft Entra Domain Services managed domain.

- Adds the Application Administrator and Groups Administrator Microsoft Entra directory-role requirements.
- Adds the Domain Services Contributor Azure RBAC role requirement.
- Aligns the prerequisites with the managed-domain deployment and secure LDAP documentation.

## Validation

- Reviewed the Markdown formatting and link rendering.

