### PR TITLE
 Fix incorrect Slack plan prerequisite (gallery SCIM app supports Ent…

### DIFF
--- a/docs/identity/saas-apps/slack-provisioning-tutorial.md
+++ b/docs/identity/saas-apps/slack-provisioning-tutorial.md
@@ -35,7 +35,7 @@ The scenario outlined in this article assumes that you already have the followin
 
 * [A Microsoft Entra tenant](~/identity-platform/quickstart-create-new-tenant.md).
 * One of the following roles: [Application Administrator](/entra/identity/role-based-access-control/permissions-reference#application-administrator), [Cloud Application Administrator](/entra/identity/role-based-access-control/permissions-reference#cloud-application-administrator), or [Application Owner](/entra/fundamentals/users-default-permissions#owned-enterprise-applications).
-** A Slack tenant on a paid plan that supports the SCIM API ([Business+](https://slack.com/pricing) or Enterprise Grid). The gallery application in this article works for both Business+ and Enterprise Grid customers.
+* A Slack tenant on a paid plan that supports the SCIM API ([Business+](https://slack.com/pricing) or Enterprise Grid). The gallery application in this article works for both Business+ and Enterprise Grid customers.
 * A user account in Slack with Team Admin permissions.
 
 ## Step 1: Plan your provisioning deployment

--- a/docs/identity/saas-apps/slack-provisioning-tutorial.md
+++ b/docs/identity/saas-apps/slack-provisioning-tutorial.md
@@ -35,7 +35,7 @@ The scenario outlined in this article assumes that you already have the followin
 
 * [A Microsoft Entra tenant](~/identity-platform/quickstart-create-new-tenant.md).
 * One of the following roles: [Application Administrator](/entra/identity/role-based-access-control/permissions-reference#application-administrator), [Cloud Application Administrator](/entra/identity/role-based-access-control/permissions-reference#cloud-application-administrator), or [Application Owner](/entra/fundamentals/users-default-permissions#owned-enterprise-applications).
-* A Slack tenant with the [Business+ plan](https://slack.com/pricing) only. Enteprise Grid customers should follow [Slack's instructions](https://api.slack.com/admins/scim#enterprise-grid) instead.
+** A Slack tenant on a paid plan that supports the SCIM API ([Business+](https://slack.com/pricing) or Enterprise Grid). The gallery application in this article works for both Business+ and Enterprise Grid customers.
 * A user account in Slack with Team Admin permissions.
 
 ## Step 1: Plan your provisioning deployment


### PR DESCRIPTION
The Prerequisites section incorrectly states the Slack gallery provisioning app is
limited to "Business+ plan only" and that Enterprise Grid customers must use a
separate path.

This is inaccurate. The Slack gallery SAML + SCIM provisioning application works on
any Slack environment that supports the SCIM API — both Business+ and Enterprise
Grid. Many Enterprise Grid customers currently use this gallery app with Entra ID
for provisioning and group sync.

This restriction was introduced in commit 1a1807b by a community contributor and
was not verified with Slack. This PR corrects the prerequisite. (Also fixes the
"Enteprise" typo that the same change introduced.)
