### PR TITLE
Fix deprecated Microsoft Docs links in Node sign-in tutorial

### DIFF
--- a/docs/identity-platform/tutorial-web-app-node-sign-in-sign-out.md
+++ b/docs/identity-platform/tutorial-web-app-node-sign-in-sign-out.md
@@ -240,7 +240,7 @@ The `/` route is the entry point to the application. It renders the *views/index
     
                 /**
                  * By default, MSAL Node will add OIDC scopes to the auth code url request. For more information, visit:
-                 * https://docs.microsoft.com/azure/active-directory/develop/v2-permissions-and-consent#openid-connect-scopes
+                 * https://learn.microsoft.com/azure/active-directory/develop/v2-permissions-and-consent#openid-connect-scopes
                  */
                 scopes: [],
             };
@@ -250,7 +250,7 @@ The `/` route is the entry point to the application. It renders the *views/index
     
                 /**
                  * By default, MSAL Node will add OIDC scopes to the auth code request. For more information, visit:
-                 * https://docs.microsoft.com/azure/active-directory/develop/v2-permissions-and-consent#openid-connect-scopes
+                 * https://learn.microsoft.com/azure/active-directory/develop/v2-permissions-and-consent#openid-connect-scopes
                  */
                 scopes: [],
             };
@@ -307,7 +307,7 @@ The `/` route is the entry point to the application. It renders the *views/index
             /**
              * Construct a logout URI and redirect the user to end the
              * session with Microsoft Entra ID. For more information, visit:
-             * https://docs.microsoft.com/azure/active-directory/develop/v2-protocols-oidc#send-a-sign-out-request
+             * https://learn.microsoft.com/azure/active-directory/develop/v2-protocols-oidc#send-a-sign-out-request
              */
             //For external tenant
             //const logoutUri = `${this.config.msalConfig.auth.authority}${TENANT_SUBDOMAIN}.onmicrosoft.com/oauth2/v2.0/logout?post_logout_redirect_uri=${this.config.postLogoutRedirectUri}`;
@@ -462,7 +462,7 @@ The `/` route is the entry point to the application. It renders the *views/index
         /**
          * Construct a logout URI and redirect the user to end the
             * session with Azure AD. For more information, visit:
-            * https://docs.microsoft.com/azure/active-directory/develop/v2-protocols-oidc#send-a-sign-out-request
+            * https://learn.microsoft.com/azure/active-directory/develop/v2-protocols-oidc#send-a-sign-out-request
             */
         const logoutUri = `${this.config.msalConfig.auth.authority}${TENANT_SUBDOMAIN}.onmicrosoft.com/oauth2/v2.0/logout?post_logout_redirect_uri=${this.config.postLogoutRedirectUri}`;
 


### PR DESCRIPTION
This PR updates deprecated docs.microsoft.com links to the current learn.microsoft.com format in the Node.js sign-in/sign-out tutorial.

The change is limited to documentation link maintenance and does not modify technical guidance or sample behavior.