### PR TITLE
Removed Power BI MTO limitation - MTO is GA in Power BI and Fabric

### DIFF
--- a/docs/includes/user-type-workload-limitations-include.md
+++ b/docs/includes/user-type-workload-limitations-include.md
@@ -11,6 +11,5 @@ ms.custom: include file
 
 | App or service | Limitations |
 | --- | --- |
-| Power BI | Support for a `UserType` value of `Member` in Power BI is currently in preview. For more information, see [Distribute Power BI content to external guest users with Microsoft Entra B2B](/fabric/enterprise/powerbi/service-admin-entra-b2b). |
 | Azure Virtual Desktop | For limitations, see [Prerequisites for Azure Virtual Desktop](/azure/virtual-desktop/prerequisites#users). |
 | Microsoft Teams | For limitations, see [Collaborate with guests from other Microsoft 365 cloud environments](/microsoft-365/solutions/collaborate-guests-cross-cloud). |


### PR DESCRIPTION
Support for UserType = Member (MTO) is GA in Fabric.
I removed the limitation from the docs.