### PR TITLE
Correct Microsoft Cloud App Security naming and add user permissions

### DIFF
--- a/docs/identity/role-based-access-control/includes/security-operator.md
+++ b/docs/identity/role-based-access-control/includes/security-operator.md
@@ -30,12 +30,16 @@ This is a [privileged role](../privileged-roles-permissions.md). Users with this
 > | microsoft.azure.supportTickets/allEntities/allTasks | Create and manage Azure support tickets |
 > | microsoft.directory/auditLogs/allProperties/read | Read all properties on audit logs, excluding custom security attributes audit logs |
 > | microsoft.directory/authorizationPolicy/standard/read | Read standard properties of authorization policy |
-> | microsoft.directory/cloudAppSecurity/allProperties/allTasks | Create and delete all resources, and read and update standard properties in Microsoft Defender for Cloud Apps |
+> | microsoft.directory/cloudAppSecurity/allProperties/allTasks | Create and delete all resources, and read and update standard properties in Microsoft Cloud App Security |
 > | microsoft.directory/identityProtection/allProperties/allTasks | Create and delete all resources, and read and update standard properties in Microsoft Entra ID Protection<br/>[![Privileged label icon.](../media/permissions-reference/privileged-label.png)](../privileged-roles-permissions.md) |
 > | microsoft.directory/privilegedIdentityManagement/allProperties/read | Read all resources in Privileged Identity Management |
 > | microsoft.directory/provisioningLogs/allProperties/read | Read all properties of provisioning logs |
 > | microsoft.directory/signInReports/allProperties/read | Read all properties on sign-in reports, including privileged properties |
-> | microsoft.intune/allEntities/read | Read all resources in Microsoft Intune |
+> | microsoft.directory/users/disable | Disable Users |
+> | microsoft.directory/users/enable | Enable Users |
+> | microsoft.directory/users/invalidateAllRefreshTokens | Force sign-out by invalidating user refresh tokens |
+> | microsoft.directory/users/password/update | 
+> | microsoft.intune/allEntities/read | Read all resources in Microsoft Intune | Reset passwords for all users |
 > | microsoft.office365.securityComplianceCenter/allEntities/allTasks | Create and delete all resources, and read and update standard properties in the Microsoft 365 Security and Compliance Center |
 > | microsoft.office365.supportTickets/allEntities/allTasks | Create and manage Microsoft 365 service requests |
 > | microsoft.windows.defenderAdvancedThreatProtection/allEntities/allTasks | Manage all aspects of Microsoft Defender for Endpoint |


### PR DESCRIPTION
Updated the documentation to reflect the correct naming of Microsoft Cloud App Security and updated permissions for user management to reflect the latest for the Security Operator role in Entra.