### PR TITLE
Document related tenant drill-down, Microsoft-managed, and investigation API

### DIFF
--- a/docs/id-governance/tenant-governance/how-to-interpret-discovery-data.md
+++ b/docs/id-governance/tenant-governance/how-to-interpret-discovery-data.md
@@ -3,7 +3,7 @@ title: Interpret tenant discovery data (preview)
 titleSuffix: Microsoft Entra ID Governance
 description: Learn how to interpret tenant discovery data, signals, and metrics in Microsoft Entra Tenant Governance to assess related tenants
 ms.topic: how-to
-ms.date: 03/05/2026
+ms.date: 07/14/2026
 ---
 
 # Interpret tenant discovery data (preview)
@@ -39,6 +39,7 @@ Key things to look for initially:
 - **How many related tenants exist**
 - **Which signals caused discovery**
 - **Whether the tenant appears active or historical**
+- **Whether the tenant is Microsoft managed** (a Microsoft-owned infrastructure tenant)
 
 This step establishes scope, not judgment.
 
@@ -72,7 +73,31 @@ You can sort metrics from increasing to decreasing use. Use these comparisons to
 
 A tenant with recent, increasing activity typically warrants closer scrutiny than one with only historical, initial signals. For example, a tenant with active B2B guest users, active administrative sign-ins, and a shared billing account represents a stronger operational relationship. Compare this to a tenant surfaced only through historical B2B guest user presence captured at the time of discovery.
 
-## Step 4: Classify the related tenant
+## Step 4: Drill into a signal to see the underlying entities
+
+Discovery metrics are aggregated to orders of magnitude. For example, a returned value of 100 represents an actual value between 100 and 999. To move from a high-level count to specific evidence, drill into a signal to see the underlying users or applications that contribute to it.
+
+In the admin center, select a metric for a related tenant to open a details panel. The panel lists the underlying entities, retrieved live from your tenant:
+
+| Signal | What the drill-down shows | Fidelity |
+|---|---|---|
+| B2B registration | Guest users from the related tenant | Exact |
+| B2B sign-ins | Users or applications with cross-tenant sign-in activity | Based on sign-in logs |
+| Admin app sign-ins | Users or applications that signed in to administrative applications | Based on sign-in logs |
+| Multitenant applications | Applications (service principals) owned by the related tenant | Exact |
+
+Keep these considerations in mind when you interpret drill-down results:
+
+- **Live versus aggregated data.** The details are retrieved live and can differ from the aggregated metric on the card. The aggregated metric refreshes only when activity crosses into a new order of magnitude.
+- **Sign-in signals are a proxy.** B2B and admin app sign-in details come from sign-in logs and are limited by your tenant's log retention period, so the details can differ from the displayed metric.
+- **Not available.** Some signals and directions, such as shared billing accounts, don't support drilling in.
+- **Privacy.** Unlike aggregated metrics, drilling in surfaces user-level and application-level identifiers. This information is available only to authorized administrators.
+
+Use drilling in to confirm a judgment before you classify a tenant. For example, drill into admin app sign-ins to see exactly which administrative applications were used and by whom.
+
+To retrieve the same underlying data programmatically, see [Investigate related tenant signals by using Microsoft Graph](how-to-investigate-related-tenants-api.md).
+
+## Step 5: Classify the related tenant
 
 Based on signals and metrics, classify each related tenant into one of three practical categories.
 
@@ -81,6 +106,7 @@ Based on signals and metrics, classify each related tenant into one of three pra
 **Characteristics:**
 
 - Clearly identifiable partner, vendor, or customer (naming, domains, users)
+- Flagged as **Microsoft managed** (a Microsoft-owned infrastructure tenant)
 - Expected B2B or application activity
 - Activity levels align with business context
 
@@ -127,5 +153,6 @@ Base the quarantine decision on related tenant signals, not on isolated analysis
 
 - [Related tenants in Tenant Governance](related-tenants.md)
 - [Signals and metrics for tenant discovery](signals-metrics.md)
+- [Investigate related tenant signals by using Microsoft Graph](how-to-investigate-related-tenants-api.md)
 - [Enable tenant discovery](how-to-enable-tenant-discovery.md)
 - [Set up a governance relationship](how-to-set-up-governance-relationship.md)

--- a/docs/id-governance/tenant-governance/how-to-investigate-related-tenants-api.md
+++ b/docs/id-governance/tenant-governance/how-to-investigate-related-tenants-api.md
@@ -14,23 +14,6 @@ Discovery signals for a related tenant are summarized as aggregated, order-of-ma
 
 This article describes the workflow for investigating related tenant signals with Microsoft Graph. For the full request and response schema, see the Microsoft Graph API reference linked in [Related content](#related-content).
 
-## Prerequisites
-
-- A Microsoft Entra Tenant Governance license. For more information, see [Tenant Governance licensing](licensing.md).
-- Related tenants must be enabled for your tenant. If it isn't enabled yet, call the [enableRelatedTenants](/graph/api/tenantgovernanceservices-tenantgovernancesetting-enablerelatedtenants?view=graph-rest-beta&preserve-view=true) action first.
-- An appropriate Microsoft Graph permission:
-
-  | Permission type | Least privileged permission |
-  |---|---|
-  | Delegated (work or school account) | `TenantGovernance-RelatedTenant.Read.All` |
-  | Application | `TenantGovernance-RelatedTenant.Read.All` |
-
-  Personal Microsoft accounts aren't supported.
-
-- For delegated access, the signed-in user must have one of the following Microsoft Entra roles: **Tenant Governance Administrator**, **Global Reader**, or **Tenant Governance Reader**.
-
-The related tenant discovery APIs are available in the Microsoft Graph **beta** endpoint.
-
 ## When to use investigation hints
 
 Investigation hints let you move from an aggregated, order-of-magnitude metric to the specific users or applications behind it. Use them when you want to:

--- a/docs/id-governance/tenant-governance/how-to-investigate-related-tenants-api.md
+++ b/docs/id-governance/tenant-governance/how-to-investigate-related-tenants-api.md
@@ -1,0 +1,100 @@
+---
+title: Investigate related tenant signals by using Microsoft Graph (preview)
+titleSuffix: Microsoft Entra ID Governance
+description: Learn how to use Microsoft Graph to retrieve the underlying users and applications behind Tenant Governance related tenant discovery signals.
+ms.topic: how-to
+ms.date: 07/14/2026
+---
+
+# Investigate related tenant signals by using Microsoft Graph (preview)
+
+[!INCLUDE [entra-tenant-governance-preview-note](~/includes/entra-tenant-governance-preview-note.md)]
+
+Discovery signals for a related tenant are summarized as aggregated, order-of-magnitude metrics. To investigate a signal in depth, you can retrieve the underlying users and applications that contribute to it. The admin center exposes this as a [drill-down experience](how-to-interpret-discovery-data.md#step-4-drill-into-a-signal-to-see-the-underlying-entities). The same data is available programmatically through Microsoft Graph.
+
+This article describes the workflow for investigating related tenant signals with Microsoft Graph. For the full request and response schema, see the Microsoft Graph API reference linked in [Related content](#related-content).
+
+## Prerequisites
+
+- A Microsoft Entra Tenant Governance license. For more information, see [Tenant Governance licensing](licensing.md).
+- Related tenants must be enabled for your tenant. If it isn't enabled yet, call the [enableRelatedTenants](/graph/api/tenantgovernanceservices-tenantgovernancesetting-enablerelatedtenants?view=graph-rest-beta&preserve-view=true) action first.
+- An appropriate Microsoft Graph permission:
+
+  | Permission type | Least privileged permission |
+  |---|---|
+  | Delegated (work or school account) | `TenantGovernance-RelatedTenant.Read.All` |
+  | Application | `TenantGovernance-RelatedTenant.Read.All` |
+
+  Personal Microsoft accounts aren't supported.
+
+- For delegated access, the signed-in user must have one of the following Microsoft Entra roles: **Tenant Governance Administrator**, **Global Reader**, or **Tenant Governance Reader**.
+
+The related tenant discovery APIs are available in the Microsoft Graph **beta** endpoint.
+
+## When to use investigation hints
+
+Investigation hints let you move from an aggregated, order-of-magnitude metric to the specific users or applications behind it. Use them when you want to:
+
+- Automate related tenant investigation as part of a security or governance workflow.
+- Export the underlying users or applications behind a signal for reporting or ticketing.
+- Correlate related tenant activity with other signals in your environment.
+
+As with the [drill-down experience](how-to-interpret-discovery-data.md#step-4-drill-into-a-signal-to-see-the-underlying-entities), investigation hints return live data that can differ from the aggregated metric, and sign-in based signals are limited by your tenant's log retention period. For more information about interpreting these results, see [Interpret tenant discovery data](how-to-interpret-discovery-data.md).
+
+## Step 1: List related tenants
+
+Retrieve the related tenants for your tenant. Each related tenant returns its discovery metrics (such as `b2BRegistrationMetrics`, `b2BSignInActivityMetrics`, `appB2BSignInActivityMetrics`, `multiTenantApplicationMetrics`, and `billingMetrics`) expanded by default.
+
+``` http
+GET https://graph.microsoft.com/beta/directory/tenantGovernance/relatedTenants
+```
+
+Identify the related tenant (by its tenant ID in the `id` property) and the signal that you want to investigate.
+
+## Step 2: Request investigation hints for a signal
+
+Investigation hints aren't returned by default. To get them, read a related tenant and use a nested `$expand` on the metric relationship that you're investigating. For example, to get the investigation steps for the B2B sign-in signal:
+
+``` http
+GET https://graph.microsoft.com/beta/directory/tenantGovernance/relatedTenants/{relatedTenantId}?$expand=b2BSignInActivityMetrics($expand=investigationHints)
+```
+
+The `investigationHints` relationship returns an ordered collection of investigation steps. The following response is illustrative and shortened for readability.
+
+``` json
+{
+  "b2BSignInActivityMetrics": {
+    "investigationHints": [
+      {
+        "stepNumber": "1",
+        "text": "Guidance that explains what this step reveals about the metric.",
+        "actionUrl": {
+          "displayName": "b2BSignInActivityMetrics.recent.inboundMonthlyTotalUsers§single§§$output",
+          "url": "https://graph.microsoft.com/beta/..."
+        }
+      }
+    ]
+  }
+}
+```
+
+## Step 3: Run the investigation steps
+
+Each step is an [investigationActionStep](/graph/api/resources/tenantgovernanceservices-investigationactionstep?view=graph-rest-beta&preserve-view=true):
+
+- **stepNumber**: The order to run the step in. Run steps in ascending order, because later steps can depend on the output of earlier steps.
+- **text**: Human-readable guidance that describes what the step reveals.
+- **actionUrl**: An [investigationActionUrl](/graph/api/resources/tenantgovernanceservices-investigationactionurl?view=graph-rest-beta&preserve-view=true) that identifies the follow-on Microsoft Graph or Azure Resource Manager (ARM) API to call:
+  - **url**: A URL template to invoke. It can contain placeholders such as `{@id}`, `{startDate}`, `{endDate}`, or `{sourceDomain}` that you resolve from the related tenant, the caller context, or the output of an earlier step. The value can be empty for steps that only transform data returned by a previous step.
+  - **displayName**: A machine-readable directive in the form `metricPath§operation§input§output` that describes how to run the step and how to chain its output into later steps.
+
+Resolve the placeholders, call each step's `url` in ascending `stepNumber` order, and combine the results to reveal the underlying users or applications behind the metric.
+
+## Related content
+
+- [Interpret tenant discovery data](how-to-interpret-discovery-data.md)
+- [Signals and metrics for tenant discovery](signals-metrics.md)
+- [Related tenants in Tenant Governance](related-tenants.md)
+- [List relatedTenants](/graph/api/tenantgovernanceservices-list-relatedtenants?view=graph-rest-beta&preserve-view=true)
+- [investigationActionStep resource type](/graph/api/resources/tenantgovernanceservices-investigationactionstep?view=graph-rest-beta&preserve-view=true)
+- [investigationActionUrl resource type](/graph/api/resources/tenantgovernanceservices-investigationactionurl?view=graph-rest-beta&preserve-view=true)

--- a/docs/id-governance/tenant-governance/related-tenants.md
+++ b/docs/id-governance/tenant-governance/related-tenants.md
@@ -3,7 +3,7 @@ title: Related tenants in Tenant Governance (preview)
 titleSuffix: Microsoft Entra ID Governance
 description: Learn how Microsoft Entra Tenant Governance discovers related tenants through identity, application, and billing signals across your organization
 ms.topic: concept-article
-ms.date: 03/10/2026
+ms.date: 07/14/2026
 ---
 
 # Related tenants in Tenant Governance (preview)
@@ -39,6 +39,14 @@ Tenant Governance discovers related tenants. You don't manually declare them. Di
 - The activity and discovery metrics associated with those signals, such as identity interactions, application usage, or billing associations
 
 These metrics describe how tenants are connected. They don't assign qualitative scores or imply that every related tenant must be governed. Instead, they provide the evidence needed to determine whether governance action is warranted.
+
+## Microsoft-managed tenants
+
+Some discovered related tenants are Microsoft-owned infrastructure tenants rather than tenants that belong to your organization or your partners. Tenant Governance identifies these tenants and flags them as **Microsoft managed**.
+
+Microsoft-managed tenants appear because routine Microsoft cloud operations create observable cross-tenant activity. They're expected and generally require no governance action. The **Microsoft managed** indicator helps you quickly recognize and set aside this class of related tenant so you can focus on tenants that need attention.
+
+The Microsoft managed indicator is available to administrators who have a Tenant Governance license and permission to read related tenants.
 
 ## Why related tenants matter
 

--- a/docs/id-governance/tenant-governance/toc.yml
+++ b/docs/id-governance/tenant-governance/toc.yml
@@ -44,6 +44,8 @@
       href: how-to-enable-tenant-discovery.md
     - name: Interpret discovery data
       href: how-to-interpret-discovery-data.md
+    - name: Investigate signals with Microsoft Graph
+      href: how-to-investigate-related-tenants-api.md
   - name: Governance relationships
     items:
     - name: Set up a governance relationship


### PR DESCRIPTION
Add public docs for two Tenant Governance UX changes and the related tenant investigation Graph API:

- how-to-interpret-discovery-data.md: add 'Step 4: Drill into a signal to see the underlying entities' (signal/fidelity table and caveats), note the Microsoft-managed indicator in the inventory and 'Known and acceptable' classification, and renumber Classify to Step 5.
- related-tenants.md: add a 'Microsoft-managed tenants' concept section covering the Microsoft managed (isMicrosoftInfrastructure) indicator.
- how-to-investigate-related-tenants-api.md: new how-to for retrieving the underlying users and applications behind a signal via the investigationHints nested \, linking to the Microsoft Graph beta reference.
- toc.yml: add the new how-to under How-to guides > Related tenants.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
