### PR TITLE
Fix link to Device Registration Troubleshooter Tool

### DIFF
--- a/docs/identity/devices/troubleshoot-hybrid-join-windows-current.md
+++ b/docs/identity/devices/troubleshoot-hybrid-join-windows-current.md
@@ -19,7 +19,7 @@ This article assumes that you have [Microsoft Entra hybrid joined devices](hybri
 - [Windows Hello for Business](/windows/security/identity-protection/hello-for-business/hello-identity-verification)
 
 > [!NOTE] 
-> To troubleshoot the common device registration issues, use [Device Registration Troubleshooter Tool](/samples/azure-samples/dsregtool/dsregtool/).
+> To troubleshoot the common device registration issues, use [Device Registration Troubleshooter Tool](https://github.com/mzmaili/DSRegTool).
 
 ## Troubleshoot join failures
 


### PR DESCRIPTION
Updated the link for the Device Registration Troubleshooter Tool to point to the GitHub repository.

Current link is broken.