### PR TITLE
Update macOS PRT section for device-authentication caveat with Secure…

### DIFF
--- a/docs/identity/devices/concept-primary-refresh-token.md
+++ b/docs/identity/devices/concept-primary-refresh-token.md
@@ -78,9 +78,11 @@ The SSO extension uses these keys to complete device registration with the Micro
 
 **macOS without Platform SSO**
 
-macOS supports Unregistered PRTs for Microsoft Edge and Registered PRTs when device is workplace joined and broker is present
+macOS supports Unregistered PRTs for Microsoft Edge and Registered PRTs when device is workplace joined and broker is present.
 
 Once registration is successfully completed, macOS initiates a sign in request signed with the Device Signing key. Microsoft Entra ID validates the request, device signing key and associated parameters, and issues PRT response.
+
+However, [Managed devices using Secure Enclave for storing device identity keys will also need to be provisioned with Enterprise SSO or Platform SSO to report device identity to Microsoft Entra ID.](../../identity-platform/apple-sso-plugin.md#device-identity-key-storage)
 
 ### [iOS and Android](#tab/other-prt-issued)
 


### PR DESCRIPTION
… Enclave

It's stated in this doc that:
- macOS without Platform SSO will still have a PRT.
- PRT is used for Conditional Access evaluation, namely device-based conditions. Thus, this doc allows to infer that a macOS device without platform SSO will still satisfy device-based Conditional Access policies. 

This is not true for devices where the device identity is stored in secure enclave, as these require PSSO for device authentication. So, I've added such disclaimer and linked the doc where this is stated.