### PR TITLE
Correct PIM-for-Groups credential-protection scope: eligible members and owners are protected

### DIFF
--- a/docs/id-governance/privileged-identity-management/concept-pim-for-groups.md
+++ b/docs/id-governance/privileged-identity-management/concept-pim-for-groups.md
@@ -34,7 +34,7 @@ To learn more about Microsoft Entra role-assignable groups, see [Create a role-a
 
 Role-assignable groups benefit from extra protections compared to non-role-assignable groups:
 
-- **Role-assignable groups** - only the Global Administrator, Privileged Role Administrator, or the group Owner can manage the group. Also, no other users can change the credentials of the users who are members or owners of the group. This protection also covers principals who are eligible for membership or ownership of the group through PIM, before activation. This feature helps prevent an admin from elevating to a higher privileged role without going through a request and approval procedure.
+- **Role-assignable groups** - only the Global Administrator, Privileged Role Administrator, or the group Owner can manage the group. Also, no other users can change the credentials of the members and owners of the group, including eligible members and owners who haven't activated yet. This feature helps prevent an admin from elevating to a higher privileged role without going through a request and approval procedure.
 - **Non-role-assignable groups** - various Microsoft Entra roles can manage these groups – that includes Exchange Administrators, Groups Administrators, User Administrators. Also, various Microsoft Entra roles can change the credentials of the users who are (active) members of the group – that includes Authentication Administrators, Helpdesk Administrators, User Administrators.
 
 To learn more about Microsoft Entra built-in roles and their permissions, see [Microsoft Entra built-in roles](~/identity/role-based-access-control/permissions-reference.md).

--- a/docs/id-governance/privileged-identity-management/concept-pim-for-groups.md
+++ b/docs/id-governance/privileged-identity-management/concept-pim-for-groups.md
@@ -34,7 +34,7 @@ To learn more about Microsoft Entra role-assignable groups, see [Create a role-a
 
 Role-assignable groups benefit from extra protections compared to non-role-assignable groups:
 
-- **Role-assignable groups** - only the Global Administrator, Privileged Role Administrator, or the group Owner can manage the group. Also, no other users can change the credentials of the users who are (active) members of the group. This feature helps prevent an admin from elevating to a higher privileged role without going through a request and approval procedure.
+- **Role-assignable groups** - only the Global Administrator, Privileged Role Administrator, or the group Owner can manage the group. Also, no other users can change the credentials of the users who are members or owners of the group. This protection also covers principals who are eligible for membership or ownership of the group through PIM, before activation. This feature helps prevent an admin from elevating to a higher privileged role without going through a request and approval procedure.
 - **Non-role-assignable groups** - various Microsoft Entra roles can manage these groups – that includes Exchange Administrators, Groups Administrators, User Administrators. Also, various Microsoft Entra roles can change the credentials of the users who are (active) members of the group – that includes Authentication Administrators, Helpdesk Administrators, User Administrators.
 
 To learn more about Microsoft Entra built-in roles and their permissions, see [Microsoft Entra built-in roles](~/identity/role-based-access-control/permissions-reference.md).

--- a/docs/includes/pim-for-groups-include.md
+++ b/docs/includes/pim-for-groups-include.md
@@ -10,4 +10,6 @@ ms.custom: include file
 ---
 
 >[!Note]
-> For groups used for elevating into Microsoft Entra roles, we recommend that you require an approval process for eligible member assignments. Assignments that can be activated without approval can leave you vulnerable to a security risk from less-privileged administrators. For example, the Helpdesk Administrator has permission to reset an eligible user's passwords.
+> For groups used for elevating into Microsoft Entra roles, we recommend that you require an approval process for eligible member assignments. Assignments that can be activated without approval can leave you vulnerable to a security risk from less-privileged administrators, who might be able to reset a user's credentials and then activate the assignment on their behalf.
+>
+> Confirm that groups used for role elevation are created as [role-assignable](~/identity/role-based-access-control/groups-concept.md). Only the Privileged Authentication Administrator and the Global Administrator can change the credentials of members and owners of a role-assignable group.

--- a/docs/includes/pim-for-groups-include.md
+++ b/docs/includes/pim-for-groups-include.md
@@ -4,7 +4,7 @@ description: include file
 author: amsliu
 ms.service: entra-id
 ms.topic: include
-ms.date: 01/31/2023
+ms.date: 07/29/2026
 ms.author: amsliu
 ms.custom: include file
 ---
@@ -12,4 +12,4 @@ ms.custom: include file
 >[!Note]
 > For groups used for elevating into Microsoft Entra roles, we recommend that you require an approval process for eligible member assignments. Assignments that can be activated without approval can leave you vulnerable to a security risk from less-privileged administrators, who might be able to reset a user's credentials and then activate the assignment on their behalf.
 >
-> Confirm that groups used for role elevation are created as [role-assignable](~/identity/role-based-access-control/groups-concept.md). Only the Privileged Authentication Administrator and the Global Administrator can change the credentials of members and owners of a role-assignable group.
+> Confirm that groups used for role elevation are created as [role-assignable](~/identity/role-based-access-control/groups-concept.md). You must be assigned at least the Privileged Authentication Administrator role to change the credentials of members and owners of a role-assignable group.


### PR DESCRIPTION
## Summary

Two related statements about credential-management protection for PIM for Groups appear to describe platform behavior that no longer exists. Both currently read as saying that a user who is only *eligible* for membership in a role-assignable group is exposed to password reset by a less-privileged administrator. Testing against a live tenant shows they are protected.

Issues are disabled on this repo, so I'm raising this as a PR. **I'd genuinely welcome the product team correcting me** — if the original statements are still accurate in some configuration I didn't cover, the right fix is to scope them rather than take my wording.

## What the docs currently say

`docs/includes/pim-for-groups-include.md` (transcluded into `concept-pim-for-groups.md` and `identity/role-based-access-control/groups-concept.md`):

> For example, the Helpdesk Administrator has permission to reset an eligible user's passwords.

`docs/id-governance/privileged-identity-management/concept-pim-for-groups.md`:

> no other users can change the credentials of the users who are **(active)** members of the group

The parenthetical implies eligible members fall outside the protection, and the note states a specific capability for the Helpdesk Administrator.

## What I measured

Commercial cloud, 2026-07-28. Attacker was a real tenant-scoped **Helpdesk Administrator** in a separate delegated session (not app-only auth, not a reused admin token). Reset attempted via `PATCH /v1.0/users/{id}` with `passwordProfile`.

| # | Target configuration | Result |
|---|---|---|
| T1 | Plain user, no roles, no groups *(control)* | **ALLOWED 204** |
| T2 | Direct ACTIVE Global Administrator *(control)* | DENIED 403 |
| T3 | Direct PIM-ELIGIBLE Global Administrator, not activated | DENIED 403 |
| T4 | ACTIVE member of role-assignable group holding ACTIVE GA *(control)* | DENIED 403 |
| T5 | **ELIGIBLE member of role-assignable group holding ACTIVE GA** | **DENIED 403** |
| T6 | ELIGIBLE member of role-assignable group only ELIGIBLE for GA | DENIED 403 |
| T7 | ACTIVE member of NON-role-assignable group *(control)* | **ALLOWED 204** |
| T8 | ACTIVE owner of role-assignable group holding ACTIVE GA | DENIED 403 |
| T9 | ELIGIBLE owner of role-assignable group holding ACTIVE GA | DENIED 403 |

All denials returned `Authorization_RequestDenied` / "Insufficient privileges to complete the operation." Controls T1 and T7 succeeded, confirming the attacker genuinely held effective Helpdesk Administrator; T2 and T4 were denied, confirming the protection logic was active during the run.

T5 and T9 are the cells that contradict the current text. T3 additionally shows the protection covers direct PIM role eligibility, which isn't documented anywhere I could find.

## Why I think the text is stale rather than wrong-from-birth

The include file carries `ms.date: 01/31/2023` and its body hasn't had a content edit since the PIM-for-Groups launch. [Rogier Dijkman documented a real bypass in this area](https://rogierdijkman.medium.com/microsoft-entra-privilege-escalation-8a51b6312822) (reported to MSRC April 2022, published January 2023) — an *eligible owner* of a Privileged Access Group reset by a User Administrator. That doesn't reproduce today either (T9 covers the Helpdesk variant).

So the most likely history is that the platform was hardened between 2022 and now and the documentation was never revisited. If that's right, a note in the article confirming the remediation would be more valuable than the wording change alone.

## What this PR changes

Deliberately **conservative** — I did not delete the security recommendation, because removing a caution on the strength of one tenant's results would be the wrong direction if I've missed a configuration.

1. **`docs/includes/pim-for-groups-include.md`** — keeps the approval-process recommendation and the "less-privileged administrators" risk framing, but replaces the specific Helpdesk Administrator claim with a pointer to the control that actually governs this: role-assignability. Adds a sentence naming Privileged Authentication Administrator / Global Administrator as the roles that can change those credentials, consistent with the [Who can reset passwords](https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/privileged-roles-permissions#who-can-reset-passwords) matrix.

2. **`concept-pim-for-groups.md`** — removes the `(active)` qualifier on the role-assignable bullet and states that the protection also covers PIM-eligible members and owners. Left the parallel `(active)` on the non-role-assignable bullet alone, since it's inert there.

## Scope limits — please read before merging

- One tenant, **commercial cloud only**. Not GCC, GCC High, or DoD.
- **Helpdesk Administrator only.** Not User Administrator (which is what Dijkman used and holds a broader permission set), not Password Administrator.
- Microsoft Graph only. Not the portal, and not the legacy portal API used in the 2022 research.
- **I did not test a non-role-assignable group nested as an eligible member of a role-assignable group.** In that shape the user is a member of no role-assignable group, so the original warning may well still hold — this is essentially the case [Compass Security described in March 2026](https://blog.compass-security.com/2026/03/common-entra-id-security-assessment-findings-part-2-privileged-unprotected-groups/). If that's the scenario the note was written for, please say so explicitly in the text rather than taking my wording; the current phrasing gives no hint that nesting is the operative condition.

## Why this matters beyond wording

Reading these two passages literally led me to file [cisagov/ScubaGear#2072](https://github.com/cisagov/ScubaGear/issues/2072) against a CISA federal baseline, reporting an escalation path that doesn't exist. A Microsoft engineer spent time trying to reproduce it and correctly could not. At least one third party has since merged a detection rule built on that issue. The documentation understates the protection Entra actually provides, which is the safe direction for a security doc, but it still produced a false vulnerability report and downstream work.
