### PR TITLE
Clarify internal IP handling in Private DNS service

### DIFF
--- a/docs/global-secure-access/concept-private-name-resolution.md
+++ b/docs/global-secure-access/concept-private-name-resolution.md
@@ -12,7 +12,7 @@ ms.date: 03/25/2026
 
 Microsoft Entra Private Access provides a quick and easy way to replace legacy VPNs. It provides granular and secure access to internal resources without exposing your full network. DNS plays a vital role by enabling name resolution for critical internal resources, and remote users don't need to know the configuration of internal DNS systems. Microsoft Entra Private DNS with Quick Access offers a simple setup that uses Connector local resolvers to respond to DNS queries for internal resources.
 
-Private DNS service allows you to add domain suffixes for the organization to the Quick Access configuration. This automatically updates the traffic forwarding profile for clients. Once configured, any DNS queries for a fully qualified domain name (FQDN) that ends with the matching suffixes from client devices are sent to the DNS proxy at a GSA edge for resolution. If a cached result is available, DNS responses are returned to the clients. Otherwise, the DNS proxy forwards the request to the Connector, which sends the DNS query to its DNS server for resolution. The Connector then passes the responses back to the edge, which returns the query to the client. The GSA client then assigns a synthetic IP address, and returns it back to the application. The synthetic IP is used to steer the application traffic to GSA edges.
+Private DNS service allows you to add domain suffixes for the organization to the Quick Access configuration. This automatically updates the traffic forwarding profile for clients. Once configured, any DNS queries for a fully qualified domain name (FQDN) that ends with the matching suffixes from client devices are sent to the DNS proxy at a GSA edge for resolution. If a cached result is available, DNS responses are returned to the clients. Otherwise, the DNS proxy forwards the request to the Connector, which sends the DNS query to its DNS server for resolution. The Connector then passes the responses back to the edge, which returns the query to the client. The GSA client then returns the (original) internal IP back to the application. 
 
 A high-level Private DNS flow for Windows clients is shown in the following diagram.
 
@@ -31,7 +31,7 @@ A high-level Private DNS flow for Windows clients is shown in the following diag
 1. User requests a DNS query for `app.contoso.com`. If not cached locally, the DNS query is sent to the DNS proxy at the GSA edge. 
 1. DNS proxy either responds from its cache or forwards the query to the Connector Group defined in Quick Access.  
 1. The connector server sends the DNS query to the DNS servers configured at operating system level. 
-1. DNS proxy responds back to the client with the internal IP. The client stores the internal IP address and returns a synthetic IP to the application.
+1. DNS proxy responds back to the client with the internal IP. 
 
 
 


### PR DESCRIPTION
Updated the explanation of the Private DNS service to clarify the handling of internal IP addresses.

Synthetic IPs are only used if FQDNs are configured as App Segments. The Private DNS feature (using NRPT) returns internal/orginal IPs.

I've corrected the texts but in the picture is also a wrong reference to a syntetic IP -> https://learn.microsoft.com/en-us/entra/global-secure-access/media/concept-private-name-resolution/queries.png