### PR TITLE
Add PIM custom extensions to ID Governance licensing table 

### DIFF
--- a/docs/includes/licensing-governance.md
+++ b/docs/includes/licensing-governance.md
@@ -89,6 +89,7 @@ The following table shows what features associated with identity governance are 
 |[Privileged Identity Management (PIM)](~/id-governance/privileged-identity-management/pim-configure.md)||| :white_check_mark: | :white_check_mark: | :white_check_mark: ||
 |[PIM For Groups](~/id-governance/privileged-identity-management/concept-pim-for-groups.md)||| :white_check_mark: | :white_check_mark: | :white_check_mark: ||
 |[PIM Conditional Access Controls](../id-governance/privileged-identity-management/pim-how-to-change-default-settings.md#on-activation-require-microsoft-entra-conditional-access-authentication-context)||| :white_check_mark: | :white_check_mark: | :white_check_mark: ||
+|[PIM - Custom extensions for role activation (Preview)](/entra/id-governance/privileged-identity-management/privileged-identity-management-custom-extensions)|||| :white_check_mark: | :white_check_mark: ||
 |**Other**|**Free**|**Microsoft Entra ID P1**|**Microsoft Entra ID P2**|**Microsoft Entra ID Governance**| **Microsoft Entra Suite** | **Microsoft Agent 365** |
 |[Identity governance dashboard](~/id-governance/governance-dashboard.md)| | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: ||
 |[Insights and reporting - Inactive guest accounts](~/identity/users/clean-up-stale-guest-accounts.md)|||| :white_check_mark: | :white_check_mark: ||


### PR DESCRIPTION
Documents that Privileged Identity Management (PIM) custom extensions for
role activation require Microsoft Entra ID Governance or Microsoft Entra
Suite (not Microsoft Entra ID P2 alone). Adds a row to the ID Governance
features-by-license table on the licensing-fundamentals page.