### PR TITLE
Workload Flexible Federated Identity Credentials - Update for GitHub on supported claims

### DIFF
--- a/docs/workload-id/workload-identities-flexible-federated-identity-credentials.md
+++ b/docs/workload-id/workload-identities-flexible-federated-identity-credentials.md
@@ -82,7 +82,14 @@ Supported issuer URLs: `https://token.actions.githubusercontent.com`
 Supported claims and operators per claim: 
 
 - Claim `sub` supports operators `eq` and `matches` 
-- Claim `job_workflow_ref` supports operators `eq` and `matches` 
+- Claim `job_workflow_ref` supports operators `eq` and `matches`
+- Claim `repository_id` supports operators `eq`
+- Claim `repository_owner_id` supports operators `eq`
+
+> [!NOTE]
+>
+> Starting July 15, 2026, GitHub applies the immutable format automatically to repositories that are created, renamed, or transferred.
+> See [Migrate GitHub Actions federated credentials to immutable subjects](./workload-identities-github-immutable-subjects.md) for more information.
 
 ### [GitLab](#tab/gitlab)
 


### PR DESCRIPTION
Thanks to Zachary as the concepts page didn't explain this recent change: https://learn.microsoft.com/en-us/answers/questions/5962544/failed-to-add-federated-credential-for-github