### PR TITLE
Update FAQ on dynamic groups and agent accounts

### DIFF
--- a/docs/agent-id/faq.yml
+++ b/docs/agent-id/faq.yml
@@ -71,7 +71,7 @@ sections:
       - question: |
           Can I use dynamic groups to manage an agent's user account?
         answer: |
-          Dynamic group membership rules don't support targeting an agent's user account. Use assigned groups to manage an agent's user account's group memberships.
+          Yes, agent's user account can be added to dynamic groups, enabling it to inherit access granted to the group.
 
   - name: Authentication and consent
     questions:


### PR DESCRIPTION
Clarified the use of dynamic groups for managing an agent's user account.