### PR TITLE
Clarify default 365-day expiration in ARM API example

### DIFF
--- a/docs/id-governance/privileged-identity-management/pim-resource-roles-assign-roles.md
+++ b/docs/id-governance/privileged-identity-management/pim-resource-roles-assign-roles.md
@@ -2,7 +2,7 @@
 title: Assign Azure resource roles in Privileged Identity Management
 description: Learn how to assign Azure resource roles in Privileged Identity Management (PIM).
 ms.topic: how-to
-ms.date: 04/23/2026
+ms.date: 08/06/2026
 ms.custom: sfi-ga-nochange, sfi-image-nochange
 #Customer Intent: As an Azure resource administrator, I want to assign Azure resource roles using PIM to provide just-in-time access to subscriptions, resource groups, and other Azure resources.
 ---
@@ -126,6 +126,9 @@ PUT https://management.azure.com/providers/Microsoft.Subscription/subscriptions/
   }
 }
 ````
+
+> [!NOTE]
+> The `duration` field (value `P365D` in this example) sets the eligible assignment to expire after 365 days. To create permanent eligibility, configure the role management policy at the target scope to allow it.
 
 ### Response
 


### PR DESCRIPTION
The ARM API example under "Assign a role using Azure Resource Manager API" shows a request body with "duration": "P365D" but does not explain what this default means or how to change it. Readers who copy the example verbatim end up with role assignments that expire after 365 days without a signal that this is configurable.

This change adds a NOTE block immediately after the request body code fence, explaining that the duration field sets a bounded 365-day eligibility and that permanent eligibility requires the role management policy at the target scope to allow it.

Also bumps ms.date to reflect the update.