### PR TITLE
Change MS Graph Bicep extension to version 1.0.0

### DIFF
--- a/docs/workload-id/workload-identity-federation-config-app-trust-managed-identity.md
+++ b/docs/workload-id/workload-identity-federation-config-app-trust-managed-identity.md
@@ -131,7 +131,7 @@ az rest --method POST --uri 'https://graph.microsoft.com/applications/{app_regis
 This example shows how to use Bicep to create a FIC to make your app trust the assigned managed identity. Replace the placeholders with the appropriate values.
 
 ```Bicep
-extension 'br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:0.1.8-preview'
+extension 'br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:1.0.0'
 
 param myWorkloadManagedIdentity string = '[MANAGED-IDENTITY-NAME]'
 param applicationDisplayName string = '[APPLICATION-DISPLAYNAME]'


### PR DESCRIPTION
Version 1.0.0 of the Microsoft Graph Bicep extension has been released about a year ago and should be used in sample snippets.