### PR TITLE
Document configuring the accidental deletion threshold via Microsoft Graph

### DIFF
--- a/docs/identity/app-provisioning/accidental-deletions.md
+++ b/docs/identity/app-provisioning/accidental-deletions.md
@@ -42,9 +42,9 @@ To enable accidental deletion prevention:
     If the deletion threshold is met, an email is sent.
 1. Select **Save** to save the changes.
 
+::: zone pivot="app-provisioning"
 ## Configure accidental deletion prevention by using Microsoft Graph
 
-::: zone pivot="app-provisioning"
 You can also configure the deletion threshold without using the admin center, by writing the `SyncNotificationSettings` synchronization secret.
 
 ```http
@@ -66,9 +66,9 @@ Content-type: application/json
 `DeleteThresholdEnabled` corresponds to the **Prevent accidental deletions** check box, and `DeleteThresholdValue` to the **Accidental deletion threshold**.
 
 > [!IMPORTANT]
-> This request replaces the entire secrets collection. Any key you omit is removed, and its setting reverts to the service default. Include every key the job needs, such as `BaseAddress`, `SecretToken`, and `SyncAll`, in the same request.
+> This request replaces the entire secrets collection. Any key you omit is removed, and its setting reverts to the service default. The preceding example sets only the keys it needs to show. Include every other key the job already uses, such as `SyncAll` for the sync scope, in the same request.
 
-Synchronization secrets can't be read back through Microsoft Graph, so there's no way to verify the resulting configuration through the API. To confirm what was applied, view **Provisioning** > **Settings** in the admin center.
+Synchronization secrets can't be read back through Microsoft Graph, so there's no way to verify the resulting configuration through the API. To confirm what was applied, view **Provisioning** > **Settings** in the Microsoft Entra admin center.
 ::: zone-end
 
 When the deletion threshold is met, the job goes into quarantine, and a notification email is sent. The quarantined job can then be allowed or rejected. To learn more about quarantine behavior, see [Application provisioning in quarantine status](application-provisioning-quarantine-status.md).

--- a/docs/identity/app-provisioning/accidental-deletions.md
+++ b/docs/identity/app-provisioning/accidental-deletions.md
@@ -42,6 +42,35 @@ To enable accidental deletion prevention:
     If the deletion threshold is met, an email is sent.
 1. Select **Save** to save the changes.
 
+## Configure accidental deletion prevention by using Microsoft Graph
+
+::: zone pivot="app-provisioning"
+You can also configure the deletion threshold without using the admin center, by writing the `SyncNotificationSettings` synchronization secret.
+
+```http
+PUT https://graph.microsoft.com/v1.0/servicePrincipals/{servicePrincipalId}/synchronization/secrets
+Content-type: application/json
+
+{
+  "value": [
+    { "key": "BaseAddress", "value": "https://contoso.com/scim" },
+    { "key": "SecretToken", "value": "<secret token>" },
+    {
+      "key": "SyncNotificationSettings",
+      "value": "{\"DeleteThresholdEnabled\":true,\"DeleteThresholdValue\":30}"
+    }
+  ]
+}
+```
+
+`DeleteThresholdEnabled` corresponds to the **Prevent accidental deletions** check box, and `DeleteThresholdValue` to the **Accidental deletion threshold**.
+
+> [!IMPORTANT]
+> This request replaces the entire secrets collection. Any key you omit is removed, and its setting reverts to the service default. Include every key the job needs, such as `BaseAddress`, `SecretToken`, and `SyncAll`, in the same request.
+
+Synchronization secrets can't be read back through Microsoft Graph, so there's no way to verify the resulting configuration through the API. To confirm what was applied, view **Provisioning** > **Settings** in the admin center.
+::: zone-end
+
 When the deletion threshold is met, the job goes into quarantine, and a notification email is sent. The quarantined job can then be allowed or rejected. To learn more about quarantine behavior, see [Application provisioning in quarantine status](application-provisioning-quarantine-status.md).
 
 ## Recovering from an accidental deletion


### PR DESCRIPTION
## Summary

`docs/identity/app-provisioning/accidental-deletions.md` documents only the admin center route for setting the deletion threshold. The same setting can be applied through Microsoft Graph, by writing the `SyncNotificationSettings` synchronization secret — useful when an enterprise application and its provisioning job are created from a script, where every other part of the configuration is already scriptable.

This adds a short section covering the request shape and two behaviours that are easy to get wrong.

## Why

`synchronizationSecret` lists both `SyncAll` and `SyncNotificationSettings` as members, but neither is described anywhere, and no page explains what shape `SyncNotificationSettings` takes. The practical result is a widely repeated belief that the deletion threshold and the sync scope are portal-only settings.

## How this was verified

Against a live tenant, on an application provisioning job using the `scim` template:

1. The admin center showed **Prevent accidental deletions** enabled with a threshold of `30`.
2. `PUT /servicePrincipals/{id}/synchronization/secrets` with `SyncNotificationSettings` set to `{"DeleteThresholdEnabled":true,"DeleteThresholdValue":17}`.
3. The admin center then showed a threshold of `17`.

A distinguishing value was used deliberately: an earlier attempt wrote the same value the portal already had, which proved nothing.

Two related observations are included because both cost time to discover:

- The `PUT` replaces the whole secrets collection, so omitting a key removes it and reverts that setting to its default. Writing only `BaseAddress` and `SecretToken` silently reset the sync scope.
- Secrets can't be read back through Graph, so the result can't be asserted through the API — the admin center is the only way to confirm what was applied. That is presumably why the setting is assumed to be unscriptable.

## Note for reviewers

The `Enabled` and `Recipients` keys also appear inside `SyncNotificationSettings` in some community posts. I've deliberately left them out, because I only varied `DeleteThresholdValue` and can't speak to the others. If the full documented shape is known internally, it would be worth including.