### PR TITLE
Update provisioning agent configuration instructions

### DIFF
--- a/docs/identity/app-provisioning/on-premises-scim-provisioning.md
+++ b/docs/identity/app-provisioning/on-premises-scim-provisioning.md
@@ -38,11 +38,10 @@ The Microsoft Entra provisioning service supports a [SCIM 2.0](https://techcommu
  :::image type="content" source="~/includes/media/app-provisioning-sql/download-1.png" alt-text="Screenshot of download location for agent." lightbox="~/includes/media/app-provisioning-sql/download-1.png":::
 
  8. Leave the portal and open the provisioning agent installer, agree to the terms of service, and select **Install**.
- 9. Wait for the Microsoft Entra provisioning agent configuration wizard and then select **Next**.
- 10. In the **Select Extension** step, select **On-premises application provisioning** and then select **Next**.    
- 11. The provisioning agent uses the operating system's web browser to display a popup window for you to authenticate to Microsoft Entra ID, and potentially also your organization's identity provider. If you're using Microsoft Edge on Windows Server, ensure that Microsoft sites aren't blocked. If your organization requires legacy browser support, you can use [Microsoft Edge with IE Mode](/deployedge/edge-ie-mode) and add Microsoft sites to the trusted site list.
- 12. Provide credentials for a Microsoft Entra administrator when you're prompted to authorize. The user is required to have at least the [Hybrid Identity Administrator](/entra/identity/role-based-access-control/permissions-reference#hybrid-identity-administrator) role.
- 13. Select **Confirm** to confirm the setting. Once installation is successful, you can select **Exit**, and also close the Provisioning Agent Package installer.
+ 9. Wait for the Microsoft Entra provisioning agent configuration wizard. On the Welcome page, clear the Connect to your Active Directory domain(s) checkbox, and then select **Next**.
+ 10. The provisioning agent uses the operating system's web browser to display a popup window for you to authenticate to Microsoft Entra ID, and potentially also your organization's identity provider. If you're using Microsoft Edge on Windows Server, ensure that Microsoft sites aren't blocked. If your organization requires legacy browser support, you can use [Microsoft Edge with IE Mode](/deployedge/edge-ie-mode) and add Microsoft sites to the trusted site list.
+ 11. Provide credentials for a Microsoft Entra administrator when you're prompted to authorize. The user is required to have at least the [Hybrid Identity Administrator](/entra/identity/role-based-access-control/permissions-reference#hybrid-identity-administrator) role.
+ 12. Select **Confirm** to confirm the setting. Once installation is successful, you can select **Exit**, and also close the Provisioning Agent Package installer.
 
 
 ## Configure the connection via the provisioning agent


### PR DESCRIPTION
The provisioning agent configuration wizard has changed. The Select Extension page is no longer displayed. For on-premises SCIM provisioning, users must instead clear Connect to your Active Directory domain(s) on the Welcome page before selecting Next. This change updates step 9 and removes the outdated step 10.