### PR TITLE
Remove guidance for legacy My Apps and My Staff experience settings

### DIFF
--- a/docs/fundamentals/how-to-manage-user-profile-info.md
+++ b/docs/fundamentals/how-to-manage-user-profile-info.md
@@ -165,8 +165,6 @@ The following settings can be managed from **User settings**.
   - [External user leave settings](~/external-id/self-service-sign-up-user-flow.yml#enable-self-service-sign-up-for-your-tenant)
   - Collaboration restrictions
 - Manage user feature settings
-  - Users can use preview features for My Apps
-  - Administrators can access My Staff
 
 ## Edit multiple users at once
 

--- a/docs/identity/authentication/how-to-authentication-qr-code.md
+++ b/docs/identity/authentication/how-to-authentication-qr-code.md
@@ -32,7 +32,7 @@ Before you enable QR code authentication method, review the best practices for u
 - Shared device mode enabled on the shared devices (optional but highly recommended). 
 - A printer to print 2" x 2" QR codes. 
 - To access QR code authentication on Teams, Teams app installed on the shared device would require these versions: Android version 1.0.0.2024143204 or later, and iOS version 1.0.0.77.2024132501 or later.
-- [Enable and setup My Staff portal](~/identity/role-based-access-control/my-staff-configure.md#how-to-enable-my-staff) if you plan for frontline managers to use My Staff to provision, manage, and reset QR code and PINs. 
+- [Set up the My Staff portal](~/identity/role-based-access-control/my-staff-configure.md) if you plan for frontline managers to use My Staff to provision, manage, and reset QR code and PINs. 
 
 ## Enable QR code authentication method
 

--- a/docs/identity/enterprise-apps/end-user-experiences.md
+++ b/docs/identity/enterprise-apps/end-user-experiences.md
@@ -2,9 +2,10 @@
 title: End-user experiences for applications
 description: Learn about the customizable ways to deploy applications to end users in your organization with Microsoft Entra ID.
 ms.topic: concept-article
-ms.date: 04/29/2025
+ms.date: 09/04/2026
 ms.reviewer: lenalepa
 ms.custom: enterprise-apps
+ai-usage: ai-assisted
 
 #customer intent: As an IT admin with Microsoft Entra ID, I want to deploy applications to end users in my organization, so that they can access the applications through the app launchers such as My Apps and Microsoft 365.
 
@@ -64,18 +65,16 @@ When an authorized user selects one of these application-specific links, they fi
 These links use the same access control mechanisms as My Apps and Microsoft 365. Only those users or groups who are assigned to the application in the Microsoft Entra admin center are able to successfully authenticate. However, any user who is unauthorized see's a message explaining that they aren't granted access. The unauthorized user is given a link to load My Apps to view available applications that they do have access to.
 
 
-## Manage preview settings
+<a name="manage-preview-settings"></a>
 
-As an admin, you can choose to try out new app launcher features while they are in preview. Enabling a preview feature means that the feature is turned on for your organization. The preview feature is also reflected in the My Apps portal and other app launchers for all your users.
+## Legacy My Apps experience settings
 
-To enable or disable previews for your app launchers:
+The legacy My Apps preview settings, such as **Users can use preview features for My Apps**, are no longer used by the My Apps portal or other app launchers. These settings don't affect what your users see or how the app launchers behave.
 
-1. Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com) as at least a [Cloud Application Administrator](~/identity/role-based-access-control/permissions-reference.md#cloud-application-administrator).
-1. Browse to **Entra ID** > **Enterprise apps**.
-1. On the left menu, select **App launchers**, then select **Settings**.
-1. Under **Preview settings**, toggle the checkboxes for the previews you want to enable or disable. To opt into a preview, toggle the associated checkbox to the checked state. To opt out of a preview, toggle the associated checkbox to the unchecked state.
-1. Select **Save**. Wait a few minutes for the changes to take effect.
-Navigate to the My Apps portal and verify that the preview you enabled or disabled is reflected.
+> [!NOTE]
+> The legacy My Apps and My Staff experience settings are no longer used by the service and don't affect user behavior. These settings are being removed from the Microsoft Entra admin center. No administrator action is required.
+
+To control what your users see in My Apps, assign users and groups to applications and organize applications with collections. For more information, see [Create collections on the My Apps portal](access-panel-collections.md).
 
 ## Related content
 

--- a/docs/identity/role-based-access-control/my-staff-configure.md
+++ b/docs/identity/role-based-access-control/my-staff-configure.md
@@ -2,9 +2,10 @@
 title: Use My Staff to delegate user management
 description: Delegate user management using My Staff and administrative units
 ms.topic: how-to
-ms.date: 02/12/2025
+ms.date: 09/04/2026
 ms.reviewer: lenalepa
 ms.custom: oldportal;it-pro;, sfi-image-nochange
+ai-usage: ai-assisted
 ---
 # Manage your users with My Staff
 
@@ -33,21 +34,14 @@ To complete the steps in this article, you need the following resources and priv
   * [Microsoft 365 F1 or F3](https://www.microsoft.com/licensing/news/m365-firstline-workers)
   * [Enterprise Mobility + Security (EMS) E3 or E5](https://www.microsoft.com/microsoft-365/enterprise-mobility-security/compare-plans-and-pricing) or [Microsoft 365 E3 or E5](https://www.microsoft.com/microsoft-365/compare-microsoft-365-enterprise-plans)
 
-## How to enable My Staff
+<a name="how-to-enable-my-staff"></a>
 
+## Who can access My Staff
 
-After configuring administrative units, you can apply this scope to your users who access My Staff. Only users who are assigned an administrative role can access My Staff. To enable My Staff, complete the following steps:
+Access to My Staff is determined by administrative role assignment. Only users who are assigned an administrative role can access My Staff, and the administrative unit scope of that role assignment determines which users they can manage. After you configure administrative units and assign roles, those users can sign in to My Staff at [https://mystaff.microsoft.com](https://mystaff.microsoft.com).
 
-1. Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com) as at least a [User Administrator](~/identity/role-based-access-control/permissions-reference.md#user-administrator) or [Groups Administrator](~/identity/role-based-access-control/permissions-reference.md#groups-administrator).
-
-1. Browse to **Entra ID** > **Users** > **User settings**.
-
-1. Under **User feature**, select **Manage user feature settings**.
-
-1. Under **Administrators can access My Staff**, you can choose to enable for all users, selected users, or no user access.
-
-> [!Note]
-> Only users who've been assigned an admin role can access My Staff. If you enable My Staff for a user who is not assigned an admin role, they won't be able to access My Staff.
+> [!NOTE]
+> The legacy My Apps and My Staff experience settings, such as **Administrators can access My Staff** under **Manage user feature settings**, are no longer used by the service and don't affect user behavior. These settings are being removed from the Microsoft Entra admin center. No administrator action is required.
 
 ## Conditional Access
 
@@ -63,7 +57,7 @@ You'll see the service principal when you create a Conditional Access policy tha
 
 When a user selects My Staff, they are shown the names of the [administrative units](administrative-units.md) over which they have administrative permissions. In the [My Staff user documentation](https://support.microsoft.com/account-billing/manage-front-line-users-with-my-staff-c65b9673-7e1c-4ad6-812b-1a31ce4460bd), we use the term "location" to refer to administrative units. If an administrator's permissions don't have an administrative unit scope, then the permissions apply across the organization. 
 
-After My Staff has been enabled, the users who are enabled and have been assigned an administrative role can access it through [https://mystaff.microsoft.com](https://mystaff.microsoft.com). They can select an administrative unit to view the users in that unit, and select a user to open their profile.
+Users who are assigned an administrative role can access My Staff through [https://mystaff.microsoft.com](https://mystaff.microsoft.com). They can select an administrative unit to view the users in that unit, and select a user to open their profile.
 
 ### Limitations
 My Staff shows up to 999 users per administrative unit.


### PR DESCRIPTION
## Why

The legacy **My Apps** preview settings and the **Administrators can access My Staff** setting are no longer honored by the corresponding experiences. They were originally added to preview My* features years ago and have been non-functional since. The current docs still walk administrators through enabling and configuring them, which creates the false impression that these toggles control real behavior. The product team is removing the UX from the Microsoft Entra admin center, so the docs need to describe current behavior before that ships.

## What changed

| File | Change |
| --- | --- |
| `docs/identity/enterprise-apps/end-user-experiences.md` | Replaced the **Manage preview settings** procedure with a **Legacy My Apps experience settings** section explaining the settings are unused, plus a pointer to app assignment and collections as the actual way to control what users see. |
| `docs/identity/role-based-access-control/my-staff-configure.md` | Replaced the **How to enable My Staff** procedure with **Who can access My Staff**, which correctly describes access as governed by administrative role assignment and administrative unit scope. |
| `docs/fundamentals/how-to-manage-user-profile-info.md` | Removed the two legacy sub-bullets ("Users can use preview features for My Apps" and "Administrators can access My Staff") from the User settings list. |
| `docs/identity/authentication/how-to-authentication-qr-code.md` | Reworded the prerequisite from "Enable and setup My Staff portal" and dropped the now-stale `#how-to-enable-my-staff` deep link. |

Both primary articles carry this note:

> The legacy My Apps and My Staff experience settings are no longer used by the service and don't affect user behavior. These settings are being removed from the Microsoft Entra admin center. No administrator action is required.

## Notes for reviewers

- **Anchors are preserved.** I kept `<a name="manage-preview-settings">` and `<a name="how-to-enable-my-staff">` above the replacement headings so existing deep links from other docs, blog posts, and support content don't 404 into the middle of the page.
- **No screenshot updates were needed.** Neither article contains an image of the affected settings. The one general User settings screenshot in `how-to-manage-user-profile-info.md` shows the **Manage user feature settings** entry point, which is still present in the portal today, so I left it alone. It may be worth a follow-up refresh once the UX removal actually ships.
- Both edited articles got `ai-usage: ai-assisted` front matter and a refreshed `ms.date`.

No customer action is required, and the docs stay accurate after the Entra admin center UX is removed.
